### PR TITLE
ci: gate issue auto-close on waiting-on-author, repair reply-labels

### DIFF
--- a/.github/workflows/issue-timeout.yml
+++ b/.github/workflows/issue-timeout.yml
@@ -1,9 +1,26 @@
-name: Issue — Auto-close on No Response
+name: Issue - Auto-close on No Response
+
+# Closes an issue ONLY when a maintainer explicitly asked the reporter for
+# something and the reporter went quiet.
+#
+# The gate is the `waiting-on-author` label, applied deliberately. It is NOT
+# `owner-replied`, which any maintainer comment sets: keying on that closed
+# roadmap trackers, design-routed items and fixed-but-unreleased bugs one day
+# after a routine status reply. This matches the pattern already used by
+# FS25_CustomTriggerCreator.
+#
+# To make an issue eligible for auto-close, label it `waiting-on-author`.
+# Nothing else is ever touched.
 
 on:
   schedule:
     - cron: '0 */6 * * *'
   workflow_dispatch:
+
+env:
+  # Grace period before an unanswered request is closed. The welcome message
+  # advertises 24 hours, so change both together if this moves.
+  GRACE_HOURS: '24'
 
 jobs:
   close-unresponded:
@@ -12,12 +29,13 @@ jobs:
       issues: write
 
     steps:
-      - name: Close issues with owner-replied but no user follow-up after 24h
+      - name: Close waiting-on-author issues with no author follow-up
         uses: actions/github-script@v7
         with:
           script: |
             const now = Date.now();
-            const twentyFourHours = 24 * 60 * 60 * 1000;
+            const graceMs = Number(process.env.GRACE_HOURS) * 60 * 60 * 1000;
+            const MAINTAINER = ['OWNER', 'MEMBER', 'COLLABORATOR'];
 
             const issues = await github.paginate(
               github.rest.issues.listForRepo,
@@ -25,13 +43,20 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 state: 'open',
-                labels: 'owner-replied',
+                labels: 'waiting-on-author',
                 per_page: 100
               }
             );
 
             for (const issue of issues) {
               if (issue.pull_request) continue;
+
+              // An issue opened by a maintainer is an internal tracker, never a
+              // request waiting on a reporter. Never auto-close one.
+              if (MAINTAINER.includes(issue.author_association)) {
+                core.info(`Skipping #${issue.number} - maintainer authored`);
+                continue;
+              }
 
               const comments = await github.rest.issues.listComments({
                 owner: context.repo.owner,
@@ -40,35 +65,50 @@ jobs:
                 per_page: 100
               });
 
-              const ownerAssociations = ['OWNER', 'MEMBER', 'COLLABORATOR'];
-              const ownerComments = comments.data.filter(c =>
-                ownerAssociations.includes(c.author_association) && c.user.type !== 'Bot'
+              // When did a maintainer last say something? If never, nobody has
+              // asked this reporter for anything, so there is nothing owed.
+              const maintainerComments = comments.data.filter(c =>
+                MAINTAINER.includes(c.author_association) && c.user.type !== 'Bot'
               );
-              if (ownerComments.length === 0) continue;
+              if (maintainerComments.length === 0) continue;
 
-              const lastOwnerReply = Math.max(...ownerComments.map(c => new Date(c.created_at).getTime()));
-              const age = now - lastOwnerReply;
-              if (age < twentyFourHours) continue;
+              const lastAsk = Math.max(
+                ...maintainerComments.map(c => new Date(c.created_at).getTime())
+              );
 
+              // Did the reporter answer? Then the clock stops and the label goes.
               const author = issue.user.login;
-              const userRepliedAfter = comments.data.some(c =>
+              const answered = comments.data.some(c =>
                 c.user.login === author &&
-                new Date(c.created_at).getTime() > lastOwnerReply
+                new Date(c.created_at).getTime() > lastAsk
               );
-              if (userRepliedAfter) continue;
+              if (answered) {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: issue.number,
+                    name: 'waiting-on-author'
+                  });
+                  core.info(`#${issue.number} answered - cleared waiting-on-author`);
+                } catch {}
+                continue;
+              }
 
+              if (now - lastAsk < graceMs) continue;
+
+              const hours = process.env.GRACE_HOURS;
               const closeBody = [
-                `Hey @${author} — it looks like the village has gone quiet on this one. This issue is being closed automatically because there was no follow-up within **24 hours** of the last response.`,
+                `Hey @${author}, this issue has been closed automatically because the information we asked for did not arrive within **${hours} hours**.`,
                 ``,
-                `This is not a rejection! If you still have the problem, please **reopen this issue** and include:`,
+                `This is not a rejection and it is not a judgement on the report. If you still have the problem, please **reopen this issue** and add:`,
                 ``,
-                `- The relevant \`[NPC Favor]\` lines from your \`log.txt\``,
+                `- The relevant lines from your \`log.txt\``,
                 `  - Location: \`Documents/My Games/FarmingSimulator2025/log.txt\``,
-                `- Your mod version (visible in the mod manager)`,
-                `- Which NPC, quest, or interaction is involved`,
-                `- Steps to reproduce the issue`,
+                `- Your mod version, visible in the mod manager`,
+                `- Steps to reproduce it`,
                 ``,
-                `The neighbors are always happy to help — we just need a little more detail!`,
+                `We would rather help than close, so please do reopen it once you have those.`,
               ].join('\n');
 
               await github.rest.issues.createComment({
@@ -86,5 +126,5 @@ jobs:
                 state_reason: 'not_planned'
               });
 
-              core.info(`Closed issue #${issue.number} — no user follow-up after owner replied`);
+              core.info(`Closed #${issue.number} - no author follow-up`);
             }

--- a/.github/workflows/reply-labels.yml
+++ b/.github/workflows/reply-labels.yml
@@ -1,5 +1,9 @@
 name: Reply Labels
 
+# Keeps `owner-replied` / `user-replied` accurate so triage can filter on who
+# spoke last. These labels are bookkeeping only: nothing auto-closes on them.
+# The auto-close gate is `waiting-on-author`, set deliberately by a maintainer.
+
 on:
   issue_comment:
     types: [created]
@@ -10,39 +14,52 @@ permissions:
 jobs:
   label:
     runs-on: ubuntu-latest
-    if: ${{ !github.event.sender.type == 'Bot' && github.event.issue.pull_request == null }}
+    # Was: `!github.event.sender.type == 'Bot'`, which parses as
+    # `(!'Bot-or-User') == 'Bot'` -> `false == 'Bot'` -> always false, so this
+    # job never ran at all. Comparison first, negation second.
+    if: ${{ github.event.sender.type != 'Bot' && github.event.issue.pull_request == null }}
     steps:
-      - name: Determine commenter role
-        id: role
+      - name: Apply reply labels
         uses: actions/github-script@v7
         with:
           script: |
-            const sender = context.payload.sender;
-            // Skip bots
-            if (sender.type === 'Bot') {
-              core.setOutput('skip', 'true');
-              return;
-            }
-            core.setOutput('skip', 'false');
+            const issueNumber = context.payload.issue.number;
             const assoc = context.payload.comment.author_association;
-            // OWNER, MEMBER, COLLABORATOR = owner side
-            const isOwner = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(assoc);
-            core.setOutput('is_owner', isOwner ? 'true' : 'false');
+            const isMaintainer = ['OWNER', 'MEMBER', 'COLLABORATOR'].includes(assoc);
 
-      - name: Apply owner-replied label
-        if: steps.role.outputs.skip == 'false' && steps.role.outputs.is_owner == 'true'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const issue = context.payload.issue.number;
-            await github.rest.issues.addLabels({ owner: context.repo.owner, repo: context.repo.repo, issue_number: issue, labels: ['owner-replied'] });
-            try { await github.rest.issues.removeLabel({ owner: context.repo.owner, repo: context.repo.repo, issue_number: issue, name: 'user-replied' }); } catch {}
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
 
-      - name: Apply user-replied label
-        if: steps.role.outputs.skip == 'false' && steps.role.outputs.is_owner == 'false'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const issue = context.payload.issue.number;
-            await github.rest.issues.addLabels({ owner: context.repo.owner, repo: context.repo.repo, issue_number: issue, labels: ['user-replied'] });
-            try { await github.rest.issues.removeLabel({ owner: context.repo.owner, repo: context.repo.repo, issue_number: issue, name: 'owner-replied' }); } catch {}
+            const add = async (name) => {
+              try {
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: issueNumber, labels: [name]
+                });
+              } catch (e) {
+                core.info(`could not add ${name}: ${e.message}`);
+              }
+            };
+            const remove = async (name) => {
+              try {
+                await github.rest.issues.removeLabel({
+                  owner, repo, issue_number: issueNumber, name
+                });
+              } catch {
+                // not present, nothing to do
+              }
+            };
+
+            if (isMaintainer) {
+              await add('owner-replied');
+              await remove('user-replied');
+            } else {
+              await add('user-replied');
+              await remove('owner-replied');
+
+              // The reporter answering is what stops the auto-close clock.
+              // Clear the gate here rather than waiting for the 6 hourly sweep,
+              // so an answer given minutes before the deadline still counts.
+              if (context.payload.comment.user.login === context.payload.issue.user.login) {
+                await remove('waiting-on-author');
+              }
+            }


### PR DESCRIPTION
## What this fixes

`issue-timeout.yml` closed any open issue carrying `owner-replied`, and `reply-labels.yml` sets that label on **every** maintainer comment. So a routine status reply on a roadmap tracker, a design-routed item or a fixed-but-unreleased bug armed a 24 hour auto-close on it.

That has never actually fired, because `reply-labels.yml` could not run. Its job condition was:

```yaml
if: ${{ !github.event.sender.type == 'Bot' && ... }}
```

which parses as `(!'User') == 'Bot'`, so `false == 'Bot'`, always false. The label was never applied, so the sweep never found anything. The chain was armed but dormant, and repairing the condition on its own would have started closing tracking issues a day after any reply.

## The fix, both halves together

**`issue-timeout.yml`** now gates on `waiting-on-author`, a label a maintainer applies deliberately when they have actually asked the reporter for something. This is the pattern `FS25_CustomTriggerCreator` already uses, so this brings the repos into line rather than inventing anything. It also:

- skips issues opened by a maintainer, since an internal tracker is never waiting on a reporter
- clears the label instead of closing when the reporter has already answered
- keeps the grace period at 24 hours, unchanged, now hoisted into a named `GRACE_HOURS` env var so it is one line to change

**`reply-labels.yml`** condition corrected, comparison first and negation second, so `owner-replied` and `user-replied` become accurate again. They are now bookkeeping for triage filtering and **nothing closes on them**. A comment from the reporter also clears `waiting-on-author` immediately, so an answer given minutes before the deadline counts rather than losing a race with the six hourly sweep.

## Net effect

Nothing currently open can be auto-closed, because nothing carries `waiting-on-author`. From here, an issue is only ever closed automatically if someone deliberately marked it as waiting on its reporter.

## Verification

YAML parsed and the embedded `github-script` bodies syntax checked with `node --check`. Behaviour itself is not exercised until the next scheduled run.

The player-facing close message was also reworded and its em dashes removed.
