### PR TITLE
feat(npc): SF-27 designation surface and guarded-owner flip (Lane B)

### DIFF
--- a/src/NPCSystem.lua
+++ b/src/NPCSystem.lua
@@ -2756,9 +2756,17 @@ function NPCSystem:startNPCFieldWorkOwned(npc)
     pcall(function() farmlandId = g_farmlandManager:getFarmlandIdAtWorldPosition(cx, cz) end)
     if not farmlandId then return false end
 
-    -- Temporarily own the field with the local player's farm (a guaranteed real farm).
-    local jobFarmId = (g_currentMission.getFarmId and g_currentMission:getFarmId())
-        or (FarmManager and FarmManager.SINGLEPLAYER_FARM_ID) or 1
+    -- Temporarily own the field with a GUARDED real farm id (a guaranteed real farm).
+    -- [SF-27] LANE B: the flip stays mechanically (the job needs a real farm id),
+    -- but it is DEFUSED against the dedicated-server flip bug: never read
+    -- getFarmId() on a dedicated server, and never or-fallback past a possible 0.
+    -- SF's designation filter handles the rest (NPC ground never churns SF
+    -- membership, never leaks into owned surfaces, never wipes GRLE).
+    local jobFarmId = FarmManager and FarmManager.SINGLEPLAYER_FARM_ID or 1
+    if g_server == nil then
+        local fid = g_currentMission and g_currentMission.getFarmId and g_currentMission:getFarmId()
+        if fid and fid > 0 then jobFarmId = fid end
+    end
     if not self:_flipFarmlandOwnership(farmlandId, jobFarmId) then return false end
     npc._ownedFarmland = farmlandId
 

--- a/src/scripts/NPCFavorSystem.lua
+++ b/src/scripts/NPCFavorSystem.lua
@@ -1816,3 +1816,51 @@ function NPCFavorSystem:triggerContextualFavor(npc, context)
     return favor
 end
 
+
+-- =========================================================
+-- [SF-27] NPC SOIL DESIGNATION SURFACE
+-- The two read surfaces the soil bridge (SF) pulls through the mission handle.
+-- Pull-only, pcall-safe, neutral-absent (nil = not NPC-managed). Derived from
+-- each NPC's assignedFarmland. Never persisted; proximity re-derives at load.
+-- =========================================================
+
+--- Which NPC (if any) manages a farmland? Derived from the active NPCs' assigned
+--- farmland records.
+---@param farmlandId number
+---@return number|nil npcId
+function NPCFavorSystem:getNPCForFarmland(farmlandId)
+    local npcs = self.npcSystem and self.npcSystem.activeNPCs
+    if not npcs then return nil end
+    for _, npc in ipairs(npcs) do
+        local af = npc.assignedFarmland
+        if af and af.farmlandId == farmlandId then
+            return npc.id
+        end
+    end
+    return nil
+end
+
+--- Is this farmland designated NPC-managed?
+---@param farmlandId number
+---@return boolean managed
+---@return number|nil npcId
+function NPCFavorSystem:isNPCManaged(farmlandId)
+    local npcId = self:getNPCForFarmland(farmlandId)
+    if npcId then return true, npcId end
+    return false, nil
+end
+
+--- Who is working this farmland right now (the working-state window)?
+---@param farmlandId number
+---@return number|nil npcId
+function NPCFavorSystem:getWorkingState(farmlandId)
+    local npcs = self.npcSystem and self.npcSystem.activeNPCs
+    if not npcs then return nil end
+    for _, npc in ipairs(npcs) do
+        local af = npc.assignedFarmland
+        if af and af.farmlandId == farmlandId and npc.isWorking then
+            return npc.id
+        end
+    end
+    return nil
+end


### PR DESCRIPTION
SF-27 NPC soil designation surface (the NPCFavor half of the two-mod build).

- `NPCFavorSystem:isNPCManaged(farmlandId)` returns `(managed, npcId)` derived from the active NPCs' assignedFarmland records. Pull-only, neutral-absent.
- `NPCFavorSystem:getWorkingState(farmlandId)` returns the NPC working that ground right now, or nil.
- `NPCFavorSystem:getNPCForFarmland(farmlandId)` the lookup both use.
- The ownership flip (Lane B, the settled lane) now targets a GUARDED real farm id: never `getFarmId()` on a dedicated server, and never or-fallback past a possible 0. The flip stays mechanically (the job needs a real farm id); SF's designation filter handles the rest.

The SF side (the bridge that reads these surfaces and widens the soil gate) ships in a companion PR on the SoilFertilizer repo. Verified with Lua 5.1 syntax and lint; the designation logic shape is pinned in the SF suite's npc_soil_designation test.
