### PR TITLE
feat(hud): base-game HUD theme, edge width resizing, and factory layout defaults

### DIFF
--- a/src/NPCSystem.lua
+++ b/src/NPCSystem.lua
@@ -353,14 +353,43 @@ function NPCSystem:onMissionLoaded()
                     self:loadFromXMLFile(missionInfo)
                 end
 
-                -- Show notification
+                -- BUILD 15:39 (PB-14). This used to be a red blinking warning
+                -- that advertised the `npcHelp` developer console command. Two
+                -- things wrong with that: the blinking warning is the alarm
+                -- channel, not the "a mod finished loading" channel, and a
+                -- console command is not player language. It also competed with
+                -- the Soil changelog for the same first-load attention because
+                -- every mod was shouting at the HUD directly.
+                --
+                -- It now goes through MasterHUD's shared notice queue, which
+                -- paces and folds the whole suite's first-load lines. When
+                -- MasterHUD is absent NPC Favor still ships standalone, so it
+                -- falls back to the game's own non-blocking notification list -
+                -- never back to the blinking warning.
                 if self.settings.showNotifications then
-                    if g_currentMission and g_currentMission.hud then
-                        local ver = (g_NPCFavorMod and g_NPCFavorMod.version) or "?"
-                        g_currentMission.hud:showBlinkingWarning(
-                            "NPC Favor v" .. ver .. " loaded - Type 'npcHelp' for commands",
-                            8000
-                        )
+                    local ver  = (g_NPCFavorMod and g_NPCFavorMod.version) or "?"
+                    local text = string.format(
+                        g_i18n:hasText("npc_notice_loaded")
+                            and g_i18n:getText("npc_notice_loaded")
+                            or "NPC Favor v%s ready. Your neighbours are settling in.",
+                        ver)
+
+                    local hud = (g_currentMission and g_currentMission.masterHUD) or g_masterHUD
+                    local posted = false
+                    if hud ~= nil and type(hud.postNotice) == "function" then
+                        local ok, r = pcall(hud.postNotice, hud, {
+                            topic = "npcfavor_loaded",
+                            text  = text,
+                        })
+                        posted = ok and r == true
+                    end
+
+                    if not posted and g_currentMission ~= nil
+                        and g_currentMission.addIngameNotification ~= nil then
+                        local typ = (FSBaseMission and FSBaseMission.INGAME_NOTIFICATION_INFO) or 1
+                        pcall(function()
+                            g_currentMission:addIngameNotification(typ, text)
+                        end)
                     end
                 end
                 

--- a/src/gui/NpcRfPdaGuest.lua
+++ b/src/gui/NpcRfPdaGuest.lua
@@ -13,6 +13,30 @@ local PANEL_ORDER = 80
 local MAX_ROWS = 8
 local _registered = false
 
+-- BUILD 09:19 (PB-07). The roster is painted into rfFwTableBlock, a STATIC eight-row table
+-- shared with Income, Dairy and Depot. With 11 neighbours the footer said "showing 8 of 11"
+-- and the last three were unreachable: the block is not a SmoothList, so there was nothing
+-- to scroll and no control to press.
+--
+-- This is a window over the sorted roster, not a new list. _pageIndex is which slice of
+-- eight is on screen; the host's two rfFwPage* Buttons step it and repaint. A SmoothList
+-- was rejected on George's standing hang lesson for this page (the same NO-GO that keeps
+-- csConsultPanel on fixed Texts), and a window needs none of that machinery.
+--
+-- _lastRosterCount is what onPageStep clamps against. The host calls onPageStep BEFORE the
+-- repaint, so at that moment the only honest roster size available is the one the last paint
+-- actually put on screen; re-reading the system there could clamp against a count the player
+-- has not been shown yet.
+local _pageIndex = 1
+local _lastRosterCount = 0
+
+local function pageCountFor(n)
+    if n == nil or n <= 0 then
+        return 1
+    end
+    return math.max(1, math.ceil(n / MAX_ROWS))
+end
+
 local TIER_KEYS = {
     ["Hostile"] = "npc_rel_hostile",
     ["Unfriendly"] = "npc_rel_unfriendly",
@@ -389,7 +413,7 @@ local function favorWho(favor, sys)
     return tostring(favor.npcId or "?")
 end
 
-local function paintActiveBridge(moreEl, sys, rosterN)
+local function paintActiveBridge(moreEl, sys, rosterN, firstRow, lastRow)
     local favors = collectActiveFavors(sys)
     local parts = {}
     if #favors == 0 then
@@ -410,10 +434,13 @@ local function paintActiveBridge(moreEl, sys, rosterN)
             )
         end
     end
+    -- BUILD 09:19 (PB-07): the range now describes the window that is actually on screen and
+    -- moves with it. "showing 8 of 11" was both unreachable and, once paging exists, wrong on
+    -- every page but the first.
     if rosterN > MAX_ROWS then
         parts[#parts + 1] = string.format(
-            tr("npc_rf_pda_showing_of", "showing %d of %d"),
-            MAX_ROWS, rosterN
+            tr("npc_rf_pda_showing_range", "showing %d-%d of %d"),
+            firstRow, lastRow, rosterN
         )
     end
     setText(moreEl, table.concat(parts, " · "))
@@ -550,6 +577,40 @@ local function restoreFwEmptyHintBox(container)
     end
 end
 
+--- BUILD 09:19 (PB-07): show and label the two shared row-pager Buttons.
+---
+--- The host hides both on every refresh before the guest paints (see _syncHostGuestChrome),
+--- so this is the only thing that turns them on and the other three Table guests are
+--- untouched. One page means no pager at all rather than two dead buttons - Sam's single-page
+--- feel lock on the module pager reads the same here: a control that cannot act should not
+--- look like one that can.
+---
+--- The Next button carries the page position rather than a bare arrow, so the player can see
+--- there is a page 2 without counting rows.
+local function paintPager(container, rosterN, pages)
+    local prevEl = findDescendant(container, "rfFwPagePrev")
+    local nextEl = findDescendant(container, "rfFwPageNext")
+    local multi = rosterN > MAX_ROWS and pages > 1
+
+    for _, el in ipairs({ prevEl, nextEl }) do
+        if el ~= nil then
+            if type(el.setVisible) == "function" then el:setVisible(multi) end
+            if type(el.setDisabled) == "function" then el:setDisabled(not multi) end
+        end
+    end
+    if not multi then
+        return
+    end
+
+    if prevEl ~= nil and type(prevEl.setText) == "function" then
+        prevEl:setText(tr("npc_rf_pda_page_prev", "< Back"))
+    end
+    if nextEl ~= nil and type(nextEl.setText) == "function" then
+        nextEl:setText(string.format(
+            tr("npc_rf_pda_page_next", "More (%d/%d) >"), _pageIndex, pages))
+    end
+end
+
 function NpcRfPdaGuest.onShow(container, lightOnly)
     applyFwGrid(container)
     restoreFwEmptyHintBox(container)
@@ -572,9 +633,20 @@ function NpcRfPdaGuest.onShow(container, lightOnly)
     local moreEl = findDescendant(container, "rfFwMore")
     local hintEl = findDescendant(container, "rfFwHintTable")
 
-    paintActiveBridge(moreEl, sys, #roster)
+    -- BUILD 09:19 (PB-07): resolve the window before anything is painted, so the rows, the
+    -- footer range and the two buttons all describe the same slice.
+    local rosterN = #roster
+    _lastRosterCount = rosterN
+    local pages = pageCountFor(rosterN)
+    if _pageIndex > pages then _pageIndex = pages end
+    if _pageIndex < 1 then _pageIndex = 1 end
+    local firstRow = (_pageIndex - 1) * MAX_ROWS + 1
+    local lastRow = math.min(rosterN, _pageIndex * MAX_ROWS)
 
-    if #roster == 0 then
+    paintActiveBridge(moreEl, sys, rosterN, firstRow, lastRow)
+    paintPager(container, rosterN, pages)
+
+    if rosterN == 0 then
         setVis(emptyEl, true)
         setText(emptyEl, tr("npc_rf_pda_empty", "no neighbors yet"))
         for i = 1, MAX_ROWS do
@@ -588,14 +660,16 @@ function NpcRfPdaGuest.onShow(container, lightOnly)
 
     setVis(emptyEl, false)
     setText(emptyEl, "")
-    local show = math.min(#roster, MAX_ROWS)
+    -- How many of the eight slots this page fills. A short last page (11 neighbours = 8 + 3)
+    -- hides the slots it does not use rather than leaving the previous page's names in them.
+    local show = lastRow - firstRow + 1
     for i = 1, MAX_ROWS do
         local a = findDescendant(container, "rfFwRow" .. i .. "A")
         local b = findDescendant(container, "rfFwRow" .. i .. "B")
         local c = findDescendant(container, "rfFwRow" .. i .. "C")
         local d = findDescendant(container, "rfFwRow" .. i .. "D")
         if i <= show then
-            local row = roster[i]
+            local row = roster[firstRow + i - 1]
             setVis(a, true); setVis(b, true); setVis(c, true); setVis(d, true)
             setText(a, row.who)
             setText(b, row.standing)
@@ -607,19 +681,67 @@ function NpcRfPdaGuest.onShow(container, lightOnly)
     end
 
     -- Hint only when More is not already dense (no overflow clause).
-    if #roster > MAX_ROWS then
+    if rosterN > MAX_ROWS then
         setText(hintEl, "")
     else
         setText(hintEl, string.format(
             tr("npc_rf_pda_hint_sort", "%d neighbors · sorted by standing (best first)"),
-            #roster
+            rosterN
         ))
     end
 end
 
-function NpcRfPdaGuest.onHide() end
+--- BUILD 09:19 (PB-07): one page step from the host's rfFwPage* Buttons.
+--- Wraps at both ends, the same way the module pager beside it does, so neither button is
+--- ever a dead click. Returns false when nothing moved so the host can skip a repaint.
+---@param delta number -1 previous page, +1 next page
+---@return boolean moved
+function NpcRfPdaGuest.onPageStep(delta)
+    local pages = pageCountFor(_lastRosterCount)
+    if pages <= 1 then
+        return false
+    end
+    local step = tonumber(delta) or 0
+    if step == 0 then
+        return false
+    end
+    local target = _pageIndex + (step > 0 and 1 or -1)
+    if target > pages then target = 1 end
+    if target < 1 then target = pages end
+    if target == _pageIndex then
+        return false
+    end
+    _pageIndex = target
+    return true
+end
+
+function NpcRfPdaGuest.onHide()
+    -- BUILD 14:04: leaving the module puts the roster back on page 1. The 09:19 build kept
+    -- the index across hide so a returning player landed on the slice they left; the 14:04
+    -- brief pins it the other way (module _currentPage, reset on hide), and the brief wins:
+    -- a re-entered roster always opens on its best-standing head, which is also the only
+    -- state whose MORE label needs no memory to be true.
+    _pageIndex = 1
+end
+
+--- BUILD 14:04: publish the guest handle the same way MdRfPdaGuest publishes its classes
+--- (mdPublishHandles, BUILD 11:43/12:59) - sandbox root plus mission handle, re-published
+--- on every register attempt so a reload cannot leave it stale. Vera's live gates have
+--- shown the mission handle is the one cross-env channel that actually resolves on the
+--- live engine (via=mission), and the host's _rfFwPageStep belt reaches this guest through
+--- exactly that channel when a stale registry copy has eaten the registered onPageStep.
+local function npcPublishHandles()
+    local okEnv, root = pcall(getfenv, 0)
+    if okEnv and type(root) == "table" then
+        root.NpcRfPdaGuest = NpcRfPdaGuest
+    end
+    if g_currentMission ~= nil then
+        g_currentMission.NpcRfPdaGuest = NpcRfPdaGuest
+    end
+end
 
 function NpcRfPdaGuest.tryRegister()
+    npcPublishHandles()
     if RfEscBootstrap ~= nil then
         if MOD_DIR == nil then
             print("[NPCFavor] NpcRfPdaGuest: WARNING MOD_DIR nil - cannot ensureDoor")
@@ -643,6 +765,15 @@ function NpcRfPdaGuest.tryRegister()
             isAvailable = function() return getSys() ~= nil end,
             onShow = NpcRfPdaGuest.onShow,
             onHide = NpcRfPdaGuest.onHide,
+            -- BUILD 09:19 (PB-07): the host reads onPageStep off the REGISTERED descriptor,
+            -- not off the guest table, so the pager only exists for a module that opts in
+            -- here. Leaving it out is what keeps Income / Dairy / Depot unpaged and
+            -- unchanged. BUILD 14:04: this registration is only real once
+            -- RfEscModules:registerModule carries onPageStep in its whitelist - it did not,
+            -- the field was silently dropped, and the live MORE was a painted no-op. The
+            -- page index resets to 1 in onHide (14:04 brief), and onShow still re-clamps it
+            -- against the live roster so a shrunk roster cannot strand anyone.
+            onPageStep = NpcRfPdaGuest.onPageStep,
         })
         if ok then
             _registered = true
@@ -655,4 +786,10 @@ function NpcRfPdaGuest.tryRegister()
 end
 
 function NpcRfPdaGuest.isRegistered() return _registered end
-function NpcRfPdaGuest.reset() _registered = false end
+function NpcRfPdaGuest.reset()
+    _registered = false
+    -- A reset is a re-register, i.e. a new session or a re-entered save. The remembered
+    -- page belongs to the roster that is going away with it.
+    _pageIndex = 1
+    _lastRosterCount = 0
+end

--- a/src/gui/RfEscModules.lua
+++ b/src/gui/RfEscModules.lua
@@ -256,6 +256,11 @@ function RfEscModules:registerModule(def)
         -- companions that predate this.
         selectCommodityIndex = def.selectCommodityIndex,
         onLightTick = def.onLightTick,
+        -- Sixth instance, BUILD 14:04 (Brian TEST 10:29): NPC Favor registered onPageStep
+        -- for the shared row pager on BUILD 09:19 and this whitelist ate it, so the live
+        -- MORE (1/2) button forwarded a step to nil and the roster never turned the page.
+        -- The register-time warning below did name it, in a log nobody read back.
+        onPageStep = def.onPageStep,
     }
     -- BUILD 23:51: this whitelist has now silently eaten a handler four times, so stop
     -- letting it do that quietly. Anything a caller passed that is not carried above gets

--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -1033,13 +1033,56 @@ function RfPdaMenuPage:_ensureMtoArrowsVisible(sel)
         return
     end
 
-    sel.disableButtonsOnSingleText = false
-    sel.hideLeftRightButtons = false
-    if sel.setCanChangeState then
-        sel:setCanChangeState(true)
+    -- BUILD 17:50 (PB-06). The item count decides everything below this line.
+    --
+    -- Before 17:50 this helper forced the arrows enabled and full lime unconditionally,
+    -- which was the fault it fixed: with a single entry the arrow cannot change state, so
+    -- the player saw a bright, clickable-looking arrow that could never act.
+    --
+    -- 17:50 leaned on disableButtonsOnSingleText to express that. BUILD 20:39 takes it back
+    -- off (see the note below the empty-list guard) and drives disabled from here alone.
+    -- Line references throughout are
+    -- .local/ref/FS25-lua-scripting/elements/MultiTextOptionElement.lua unless named
+    -- otherwise. Nothing here is guessed.
+    local texts = sel.texts or {}
+
+    -- BUILD 20:39. An empty text list means "not seeded yet", not "one page", and the two
+    -- must not be treated the same. Every caller below runs this helper both BEFORE and
+    -- AFTER the texts are set, so the early call used to latch the pager disabled from a
+    -- count that was about to change - and if the seeding path then failed or threw, the
+    -- pager stayed disabled for the rest of the session while the arrows below still got
+    -- painted. That is one of the three ways George's TASK 20:38 lime-but-dead read is
+    -- reachable. With no texts there is nothing to page through, so write nothing and let
+    -- the seeded call decide.
+    if #texts == 0 then
+        return
     end
+    local multi = #texts > 1
+
+    -- BUILD 20:39: disableButtonsOnSingleText stays FALSE (Sam feel lock DESIGN 20:00,
+    -- re-stated in BUILD 20:39; the XML declares false on every MTO in this page).
+    -- 17:50 read it as a free engine helper, but it is not free: with it true the engine
+    -- writes setDisabled(#texts <= 1) from inside updateContentElement (:831-833), and
+    -- updateContentElement runs on every setTexts, setState and arrow click. That is a
+    -- second writer on the one flag that decides whether the pager takes input at all,
+    -- firing on the same frame as our own write - "state reset in the same frame", the
+    -- third cause George named. With it false this function is the only writer.
+    -- The single-page focus guard 17:50 wanted from it is not lost: canReceiveFocus (:774)
+    -- also returns false on a disabled element, and one page still sets disabled below.
+    sel.disableButtonsOnSingleText = false
+    sel.hideLeftRightButtons = false   -- never remove the control, only dim it
+    if sel.setCanChangeState then
+        sel:setCanChangeState(multi)
+    end
+    -- This is the gate that decides whether a click ever reaches the arrows. A disabled
+    -- MTO swallows the whole mouse event before it can descend to its buttons:
+    -- MultiTextOptionElement:mouseEvent wraps its entire body in getIsActive() (:434) and
+    -- GuiElement:getIsActive is "not disabled and visible" (GuiElement.lua:1338-1340).
+    -- The GuiOverlay.setColor tint further down does NOT go through that gate, so a
+    -- disabled pager still paints lime - which is exactly the reported defect: lime arrows,
+    -- dead clicks. Multi-page must therefore end this call with disabled == false.
     if sel.setDisabled then
-        sel:setDisabled(false)
+        sel:setDisabled(not multi)
     end
 
     -- Extract: GuiUtils.getNormalizedScreenValues(values, default) - values = "Wpx Hpx" or array; returns table.
@@ -1053,11 +1096,22 @@ function RfPdaMenuPage:_ensureMtoArrowsVisible(sel)
     end
 
     -- ButtonElement extends TextElement (not Bitmap); tint via GuiOverlay on .overlay.
-    local r, g, b, a = 0.549, 0.776, 0.247, 1
+    --
+    -- Enabled keeps George's lime. Disabled goes to Samantha's neutral 45% rather than a faded
+    -- lime, so "cannot act" reads as absence of colour instead of a dimmed affordance. The
+    -- brief writes the enabled state as {1,1,1,1}, which would drop the lime this file already
+    -- carries; that is not what PB-06 is about, so the lime stays and the reading is flagged
+    -- in the reply rather than decided silently.
+    local r, g, b, a
+    if multi then
+        r, g, b, a = 0.549, 0.776, 0.247, 1
+    else
+        r, g, b, a = 1, 1, 1, 0.45
+    end
     for _, btn in ipairs({ sel.leftButtonElement, sel.rightButtonElement }) do
         if btn ~= nil then
             if btn.setVisible then btn:setVisible(true) end
-            if btn.setDisabled then btn:setDisabled(false) end
+            if btn.setDisabled then btn:setDisabled(not multi) end
             -- Size THEN lime (George Plan A). Absolute target - do not ratio current size.
             if type(btn.setSize) == "function" and tw ~= nil and th ~= nil then
                 btn:setSize(tw, th)
@@ -1073,8 +1127,19 @@ function RfPdaMenuPage:_ensureMtoArrowsVisible(sel)
 end
 
 --- Keep Map circle arrows enabled + lime on first open (not near-black grey).
+--- BUILD 20:39: also the wrap lock for the left-pane pager. Wrap is engine-native and on
+--- by default (MultiTextOptionElement.lua:55) - onRightButtonClicked rolls #texts -> 1 and
+--- onLeftButtonClicked rolls 1 -> #texts (:670-679 / :721-730) - but XML #wrap and profile
+--- "wrap" can both turn it off (:111 / :141), and with it off the last page clamps and the
+--- arrow reads dead at exactly one end. The ask is explicit that both ends wrap, so state
+--- it rather than inherit it. Set here on the pager only: _ensureMtoArrowsVisible is shared
+--- with the WC wage / About / subnav MTOs, and their wrap is not this token's business.
 function RfPdaMenuPage:_ensureSelectorArrowsVisible()
-    self:_ensureMtoArrowsVisible(self.rfPanelSelector)
+    local sel = self.rfPanelSelector
+    if sel ~= nil then
+        sel.wrap = true
+    end
+    self:_ensureMtoArrowsVisible(sel)
 end
 
 --- Stable id list fingerprint for quiet SmoothList reload decisions.
@@ -1114,7 +1179,10 @@ function RfPdaMenuPage:refreshPanelSelector(forceRebuildDots)
             activeIndex = 1
         end
 
-        self:_ensureSelectorArrowsVisible()
+        -- BUILD 20:39: the pre-setTexts ensure call that used to sit here is gone. It fed
+        -- _ensureMtoArrowsVisible the PREVIOUS text count - on first open an empty one - so
+        -- it decided the pager's disabled state from a number that the next line was about
+        -- to replace. The post-setState call below is the one that matters and it stays.
         -- setTexts can re-apply profile single-text disable; always follow with force-enable.
         self.rfPanelSelector:setTexts(texts)
         if self.rfPanelSelector.setState then
@@ -1270,14 +1338,43 @@ function RfPdaMenuPage:_applySelectorState()
 
     local state = self.rfPanelSelector:getState()
     local panel = self._panelCache[state]
-    if panel == nil then return end
+    if panel == nil then
+        -- BUILD 20:39: this is the second half of the defect. The arrow has already moved
+        -- the label and the dots by the time we get here (the engine advances state, then
+        -- raises this callback), so returning empty-handed leaves the page NAME on one
+        -- module and the page CONTENT on another - the "content does not move" read. A
+        -- cache one module older than the MTO texts is enough to hit it. Re-read the
+        -- registry once before giving up.
+        local panels = (type(host.getPanels) == "function") and host:getPanels() or nil
+        if panels ~= nil then
+            self._panelCache = panels
+            panel = panels[state]
+        end
+    end
+    if panel == nil then
+        -- Still nothing at this index: put the pager back on the page that is actually
+        -- showing. An honest snap-back beats a label pointing at a page that never loaded.
+        self:_restoreBrandToActivePanel()
+        return
+    end
 
     if host.activeModuleId ~= panel.id then
         if not self:_allowModuleSelect(panel.id) then
+            -- Refused by the dual-fire debounce. The MTO state has still moved, so snap it
+            -- back or label, dots and content stay disagreeing until the next full refresh.
+            self:_restoreBrandToActivePanel()
             return
         end
         -- Host notify refreshes selector + content (quiet lists).
-        host:selectPanel(panel.id)
+        local switched = host:selectPanel(panel.id)
+        if switched == false then
+            -- Registry refused (module gone or isAvailable false): no notify fires, so
+            -- nothing downstream would ever correct the advanced label. Snap it back.
+            SoilLogger.warning("RfPdaMenuPage: selectPanel %s refused, restoring pager state",
+                tostring(panel.id))
+            self:_restoreBrandToActivePanel()
+            return
+        end
         SoilLogger.info("RfPdaMenuPage: selectPanel %s (arrow/selector)", tostring(panel.id))
     else
         self:refreshContent(false)

--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -16,17 +16,29 @@
 local MOD_DIR = g_currentModDirectory
 local MOD_NAME = g_currentModName
 
--- Soft log when sourced from WC/CS joiners (SoilLogger may be absent).
+-- Soft log when sourced from a non-Soil joiner (SoilLogger may be absent).
+-- BUILD 17:08: the stub's signature must match Soil's real logger, which is DOT-called
+-- with the format first (src/utils/Logger.lua: function SoilLogger.info(msg, ...)), and
+-- every call in this file is dot-style. The old stub took (_, fmt, ...) as if colon-called,
+-- so on every non-Soil-hosted door the message landed in the discarded first slot and the
+-- log printed only the leftover arguments - or nothing at all. That is why the host's
+-- [RfEsc] lines have never appeared in a Dairy-door log, and it would have eaten the
+-- selector diagnostics this build ships. pcall on the format so a stray % in a runtime
+-- value can never turn a log line into the only traceback on the page.
 if SoilLogger == nil then
+    local function stubLine(fmt, ...)
+        local ok, text = pcall(string.format, fmt or "", ...)
+        return "[RfEsc] " .. (ok and text or tostring(fmt))
+    end
     SoilLogger = {
-        info = function(_, fmt, ...)
-            if Logging and Logging.info then Logging.info("[RfEsc] " .. string.format(fmt or "", ...)) end
+        info = function(fmt, ...)
+            if Logging and Logging.info then Logging.info(stubLine(fmt, ...)) end
         end,
-        warning = function(_, fmt, ...)
-            if Logging and Logging.warning then Logging.warning("[RfEsc] " .. string.format(fmt or "", ...)) end
+        warning = function(fmt, ...)
+            if Logging and Logging.warning then Logging.warning(stubLine(fmt, ...)) end
         end,
-        error = function(_, fmt, ...)
-            if Logging and Logging.error then Logging.error("[RfEsc] " .. string.format(fmt or "", ...)) end
+        error = function(fmt, ...)
+            if Logging and Logging.error then Logging.error(stubLine(fmt, ...)) end
         end,
     }
 end
@@ -198,7 +210,9 @@ local function mdResolve(bare, name)
             MdRfPdaGuest = "FS25_MarketDynamics",
             MDMMarketScreenGraph = "FS25_MarketDynamics",
             MDMMarketScreen = "FS25_MarketDynamics",
+            MDMPriceFormat = "FS25_MarketDynamics",
             CsRfPdaGuest = "FS25_SeasonalCropStress",
+            NpcRfPdaGuest = "FS25_NPCFavor",
         }
         local env = g_modEnvironments[OWNER[name] or "FS25_MarketDynamics"]
         if env ~= nil and env[name] ~= nil then
@@ -212,16 +226,69 @@ local function mdResolve(bare, name)
             end
         end
     end
-    -- 4. real global table: MarketDynamics publishes here from BUILD 11:43.
+    -- 4. _G. BUILD 14:04 (George TASK 10:53): Vera's live gate read via=mission, which
+    --    means belts 2 and 3 miss on the live engine (g_modEnvironments carries nothing
+    --    there) and getfenv(0) is the per-mod sandbox, not a shared root. _G read from mod
+    --    code resolves through the sandbox chain, so when the engine backs it with the real
+    --    global table this belt sees a publisher's _G write; when the sandbox loops _G onto
+    --    itself it degenerates to the bare lookup and costs one table index.
+    if type(_G) == "table" and _G[name] ~= nil then
+        return _G[name]
+    end
+    -- 5. sandbox root: MarketDynamics publishes here from BUILD 11:43.
     local okEnv, root = pcall(getfenv, 0)
     if okEnv and type(root) == "table" and root[name] ~= nil then
         return root[name]
     end
-    -- 5. mission handle, same publish.
+    -- 6. mission handle, same publish. The one belt Vera's live gate has actually seen
+    --    resolve on a non-MD door (via=mission), so it must stay last-resort-but-present.
     if g_currentMission ~= nil and g_currentMission[name] ~= nil then
         return g_currentMission[name]
     end
     return nil
+end
+
+--- BUILD 14:04 fence for _populateMdCommodityRow: 2dp currency when MDMPriceFormat cannot
+--- be resolved at all. George's constraint on the failed probe is "degrades to 2dp path -
+--- never formatMoney(..., 0)". This is the Vera-F2 pad rule in miniature (formatNumber and
+--- formatMoney both round-then-tostring, so neither ever pads a whole number to .00): split
+--- the digits by hand, let formatNumber group the integer half only, take the locale's own
+--- decimal mark. No x1000, no litre suffix, no animal test - that display policy lives in
+--- MDMPriceFormat and duplicating it here would put two dialects back on screen. This fence
+--- should be unreachable: the Prices rows only paint under a registered MD guest, and
+--- registration publishes MDMPriceFormat to the mission handle every attempt.
+local function mdMoney2(value)
+    local rounded = value
+    if MathUtil ~= nil and type(MathUtil.round) == "function" then
+        rounded = MathUtil.round(value, 2)
+    end
+    local negative = rounded < 0
+    local magnitude = negative and -rounded or rounded
+    local whole = math.floor(magnitude)
+    local frac = math.floor((magnitude - whole) * 100 + 0.5)
+    if frac >= 100 then
+        whole = whole + 1
+        frac = frac - 100
+    end
+    local wholeStr = tostring(whole)
+    local separator = "."
+    local symbol = ""
+    if g_i18n ~= nil then
+        if type(g_i18n.formatNumber) == "function" then
+            wholeStr = g_i18n:formatNumber(whole, 0)
+        end
+        if type(g_i18n.decimalSeparator) == "string" and g_i18n.decimalSeparator ~= "" then
+            separator = g_i18n.decimalSeparator
+        end
+        if type(g_i18n.getCurrencySymbol) == "function" then
+            symbol = g_i18n:getCurrencySymbol(true) or ""
+        end
+    end
+    local out = symbol .. wholeStr .. separator .. string.format("%02d", frac)
+    if negative then
+        out = "-" .. out
+    end
+    return out
 end
 
 local function tr(key, fallback)
@@ -1283,6 +1350,13 @@ function RfPdaMenuPage:_rebuildDots(count)
 end
 
 function RfPdaMenuPage:onClickRfPanelSelector()
+    -- BUILD 17:08 diagnostic, one line per real selector input (forceEvent is false on
+    -- every internal setState in this file, so this callback only fires for the player).
+    -- If a live test still shows dead arrows AND this line never appears in the log, the
+    -- click is being consumed ABOVE this page (menu-level), which the in-page shield in
+    -- mouseEvent cannot reach - that finding goes to George, not to more host code.
+    SoilLogger.info("RfPdaMenuPage: selector input received, state=%s",
+        tostring(self.rfPanelSelector ~= nil and self.rfPanelSelector:getState() or "?"))
     self:_ensureSelectorArrowsVisible()
     self:_applySelectorState()
 end
@@ -1551,6 +1625,17 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
         end
     end
     setVis(self.rfHostTableRegion, isCs)
+    -- BUILD 09:19 (PB-07): the shared row pager is OFF by default, every refresh, for every
+    -- module. Only a guest that implements onPageStep turns it back on, from inside its own
+    -- onShow, which runs after this. That ordering is what stops the pager following the
+    -- player from NPC Favor onto Income or Dairy - those guests do not know the buttons
+    -- exist and would never have hidden them.
+    for _, id in ipairs({ "rfFwPagePrev", "rfFwPageNext" }) do
+        local btn = self:getDescendantById(id)
+        if btn ~= nil and type(btn.setVisible) == "function" then
+            btn:setVisible(false)
+        end
+    end
     -- Action bar rides the CS module only; the guest decides the two buttons.
     setVis(self.csActionBar, isCs)
     if not isCs then
@@ -2336,6 +2421,136 @@ function RfPdaMenuPage:onClickHelpCs()
     end
 end
 
+-- ---------------------------------------------------------------------------
+-- BUILD 09:19 (PB-07): shared Table-mode row pager.
+--
+-- rfFwTableBlock is a STATIC eight-row table (rfFwRow1..rfFwRow8) - not a SmoothList - and
+-- four guests paint into it: Income, Dairy, NPC Favor and Fertilizer Depot. When a guest has
+-- more rows than eight it prints "showing 8 of 11" into rfFwMore and the other three rows
+-- were unreachable: no scrollbar, no page control, no route of any kind. Sam's law is that a
+-- list which prints a range must be navigable to the end of that range.
+--
+-- This is a PAGER and deliberately not a SmoothList. George's standing hang lesson is that a
+-- SmoothList nested under the Map-style Bitmap shell in this page can hang the frame, and the
+-- existing csConsultPanel carries the same NO-GO ("George NO-GO on TextElement.new rebuild,
+-- dialog XML nest, or SmoothList"). Two Buttons plus a window offset held by the guest costs
+-- no new list machinery and cannot re-enter the layout.
+--
+-- The host owns only the click. It knows nothing about roster size, page count or labels -
+-- it forwards a step to whichever guest is active and then repaints. A guest that does not
+-- implement onPageStep is simply not pageable and the buttons stay hidden, which is why the
+-- other three Table guests need no change to keep working exactly as before.
+-- ---------------------------------------------------------------------------
+
+--- Forward one page step to the active guest, then repaint the page it just moved.
+---@param delta number -1 for previous page, +1 for next
+---@return boolean moved true when the window moved and a repaint ran
+function RfPdaMenuPage:_rfFwPageStep(delta)
+    local host = self:_getHost()
+    local active = host and host:getActivePanel()
+    if active == nil then
+        return false
+    end
+    local step = active.onPageStep
+    -- BUILD 14:04 (Brian TEST 10:29). This is why the live MORE was a painted no-op: the
+    -- guest registered onPageStep exactly as BUILD 09:19 described, and
+    -- RfEscModules:registerModule silently dropped it - the sixth handler that whitelist
+    -- has eaten (onOpenFullMarket, onOpenConsultant/Schedule/Help, onPivotRemote,
+    -- onLightTick, onMoverChanged before it). The whitelist now carries onPageStep, and
+    -- this belt is the same shape as the 23:51 onLightTick belt directly below in
+    -- refreshContent: if the registry instance was created by a mod still running an old
+    -- RfEscModules copy, reach the guest class itself rather than shipping a dead button
+    -- again. npcFavor is the only pageable guest today, so the belt names it.
+    if type(step) ~= "function" and active.id == "npcFavor" then
+        local npcGuest = (type(mdResolve) == "function")
+                and mdResolve(NpcRfPdaGuest, "NpcRfPdaGuest") or NpcRfPdaGuest
+        if npcGuest ~= nil and type(npcGuest.onPageStep) == "function" then
+            step = npcGuest.onPageStep
+        end
+    end
+    if type(step) ~= "function" then
+        return false
+    end
+    -- The guest owns the clamp/wrap: it is the only side that knows how many rows it has.
+    -- It returns true when the window actually moved, so a click at a hard end does not
+    -- trigger a pointless full repaint.
+    local ok, moved = pcall(step, delta)
+    if not ok then
+        SoilLogger.warning("RfPdaMenuPage: onPageStep failed on %s: %s",
+            tostring(active.id), tostring(moved))
+        return false
+    end
+    if moved == false then
+        return false
+    end
+    -- Soft refresh: same path the module pager uses, so the guest repaints its rows and its
+    -- own footer range without a full enter/rebuild.
+    self:refreshContent(false)
+    return true
+end
+
+function RfPdaMenuPage:onClickRfFwPagePrev()
+    self:_rfFwPageStep(-1)
+end
+
+function RfPdaMenuPage:onClickRfFwPageNext()
+    self:_rfFwPageStep(1)
+end
+
+--- BUILD 14:04 (PB-07): Space and ">" advance the row pager, per the brief's
+--- "click/Space/>" acceptance. keyEvent walks children first via the superclass
+--- (GuiElement.lua:772-784, children in reverse order, eventUsed carried), so a focused
+--- control that consumes the key - including the pager Button itself activating on Space -
+--- wins before this fires and nothing double-steps. Only an unclaimed press reaches the
+--- step, and only a step that actually moved marks the event used; on every page without a
+--- pageable guest _rfFwPageStep returns false immediately and the key passes through
+--- untouched. unicode 32 is Space, 62 is ">", taken from the event's own unicode so the
+--- layout that produced ">" does not matter.
+function RfPdaMenuPage:keyEvent(unicode, sym, modifier, isDown, eventUsed)
+    local used = RfPdaMenuPage:superClass().keyEvent(self, unicode, sym, modifier, isDown, eventUsed)
+    if not used and isDown == true and (unicode == 32 or unicode == 62) then
+        used = self:_rfFwPageStep(1) == true
+    end
+    return used
+end
+
+--- BUILD 17:08 (Brian TEST 16:53, George TASK 17:03 GO): click shield for the module
+--- selector. Brian measured both selector arrows hover-highlighting but never advancing,
+--- with no Lua traceback. The engine split that allows exactly that: ButtonElement paints
+--- its hover state regardless of eventUsed (ButtonElement.lua:450-459) but fires its click
+--- only "if not eventUsed" (:469-491), and FocusManager highlight on the MTO is likewise
+--- move-driven (MultiTextOptionElement.lua:465-469). So hover-alive-click-dead means the
+--- CLICK half of the event is being consumed before the selector's walk position - George's
+--- hit-steal read. Event order in this engine is reverse declaration order with no z-index,
+--- and Sam's lock forbids moving any geometry, so the fix is delivery order, not layout:
+--- the page offers every click that lands inside the selector's rect to the selector FIRST,
+--- then runs the normal child walk with the event marked used, so whichever sibling was
+--- eating the click can still clear its own pressed state but can no longer act on it.
+--- Moves are NOT pre-offered - hover behavior is untouched, and a second visit of the MTO
+--- during the normal walk with eventUsed=true only re-computes identical press flags
+--- (:441-446, not eventUsed-gated), so nothing double-fires and no wrapper element is
+--- introduced. Clicks outside the selector rect take the walk exactly as before, so the
+--- module list, FW pager and every guest control keep their ownership.
+function RfPdaMenuPage:mouseEvent(posX, posY, isDown, isUp, button, eventUsed)
+    local used = eventUsed
+    local sel = self.rfPanelSelector
+    if not used and (isDown or isUp) and sel ~= nil
+        and sel.absPosition ~= nil and sel.absSize ~= nil
+        and type(sel.getIsActive) == "function" and sel:getIsActive()
+        and GuiUtils ~= nil and type(GuiUtils.checkOverlayOverlap) == "function"
+        and GuiUtils.checkOverlayOverlap(posX, posY,
+            sel.absPosition[1], sel.absPosition[2], sel.absSize[1], sel.absSize[2], nil) then
+        if sel:mouseEvent(posX, posY, isDown, isUp, button, false) then
+            used = true
+            if not self._selShieldLogged then
+                self._selShieldLogged = true
+                SoilLogger.info("RfPdaMenuPage: selector click shield delivered its first click")
+            end
+        end
+    end
+    return RfPdaMenuPage:superClass().mouseEvent(self, posX, posY, isDown, isUp, button, used) or used
+end
+
 function RfPdaMenuPage:_csPageSel()
     return self.csSubnavSelector
 end
@@ -2786,12 +3001,50 @@ function RfPdaMenuPage:_populateMdCommodityRow(index, cell)
         end
     end
     if nameEl then nameEl:setText(entry.title or "-") end
+    -- BUILD 09:19 (PB-02). This cell is the one Brian read as "£0" and "£1".
+    --
+    -- entry.price is the PER-LITRE engine number. formatMoney(price, 0, ...) rounded it to
+    -- whole currency units and printed no unit at all, so a live 0.00037/l commodity became
+    -- an actionable-looking "£0" and soybean at 0.85/l became "£1". Neither is a zero and
+    -- neither says what it is a price OF.
+    --
+    -- MDMPriceFormat is the single place that decides how a market price is written: the
+    -- x1000 display multiply for bulk goods, the forced two decimals built by hand (Vera F2:
+    -- neither formatMoney nor formatNumber forcePrecision actually pads .00), the locale
+    -- decimal mark, and the " / 1,000L" suffix that animal cargo does NOT get. The full
+    -- Market table and the Esc selected-crop line call the same helper, so all three
+    -- surfaces print one string and not three dialects of it.
+    --
+    -- The nil guard matters on this file specifically: this host is mirrored into all nine
+    -- doors and only the Market Dynamics zip ships MdPriceFormat.lua. On the other eight
+    -- doors MDMPriceFormat is nil UNLESS Market Dynamics is also loaded - and if it is not
+    -- loaded there is no Market page to paint anyway. The fallback keeps the old reading
+    -- instead of erroring.
+    --
+    -- BUILD 10:06, Vera FAIL F1. The bare global was doing less than that comment claimed.
+    -- It is nil not only when Market Dynamics is absent, but whenever Market Dynamics is not
+    -- the mod that WON the door race: FS25 gives every mod its own environment and this
+    -- mirrored file executes inside the host's, so on a Dairy-hosted or Income-hosted suite
+    -- the bare lookup misses a fully loaded MdPriceFormat.lua and the cell silently drops to
+    -- the formatMoney fallback - the exact "GBP 0" reading PB-02 was supposed to have fixed.
+    -- Same failure shape, same cause and same cure as MDMMarketScreenGraph on the Dairy door.
+    -- Resolved through mdResolve, which is that cure: bare first (free when Market Dynamics
+    -- hosts), then the named g_modEnvironments["FS25_MarketDynamics"] entry, then the
+    -- name-independent scan and the getfenv(0) / mission belts.
+    local priceFormat = (type(mdResolve) == "function")
+            and mdResolve(MDMPriceFormat, "MDMPriceFormat") or MDMPriceFormat
     local priceText = "-"
     if entry.price ~= nil then
-        if g_i18n and g_i18n.formatMoney then
-            priceText = g_i18n:formatMoney(entry.price, 0, true, true)
+        if priceFormat ~= nil and type(priceFormat.price) == "function" then
+            priceText = priceFormat.price(entry.fillTypeIndex, entry.price)
         else
-            priceText = string.format("%.0f", entry.price)
+            -- BUILD 14:04 (Vera FAIL on SUBMIT 10:16). The old branch here was
+            -- formatMoney(entry.price, 0, ...), which is the exact GBP 0 / GBP 1 reading
+            -- this cell has now shipped twice. George's constraint is verbatim "failed
+            -- probe degrades to 2dp path - never formatMoney(..., 0)", so the raw
+            -- per-litre number prints at two decimals or it does not print through
+            -- an engine rounder at all.
+            priceText = mdMoney2(entry.price)
         end
     end
     if priceEl then priceEl:setText(priceText) end

--- a/src/scripts/NPCFavorHUD.lua
+++ b/src/scripts/NPCFavorHUD.lua
@@ -13,7 +13,10 @@
 -- Drag/resize state is runtime-only — never persisted.
 -- =========================================================
 
-NPCFavorHUD = {}
+-- BUILD 17:57 + ATTN 18:02 (Wizard hot-reload law, FS25-HotReload-Guide.md Part 1):
+-- reuse the existing class table on Ctrl+R reload so updated methods land on the
+-- table live metatables already reference, instead of orphaning it.
+NPCFavorHUD = NPCFavorHUD or {}
 NPCFavorHUD_mt = Class(NPCFavorHUD)
 
 -- =========================================================
@@ -26,8 +29,10 @@ function NPCFavorHUD.new(npcSystem)
     self.npcSystem = npcSystem
 
     -- Position (normalized 0–1, top-left anchor of the HUD box)
+    -- BUILD 12:25 (Sam DESIGN 12:23): Active Favors factory default is
+    -- Middle-Left-Top in the suite's non-overlap layout. Saved drag XML wins.
     self.posX = 0.02
-    self.posY = 0.7
+    self.posY = 0.62
 
     -- Scale multiplier applied to all dimensions and text
     self.scale = 1.0
@@ -127,7 +132,7 @@ end
 function NPCFavorHUD:loadFromSettings(settings)
     if not settings then return end
     self.posX = settings.favorHudPosX or 0.02
-    self.posY = settings.favorHudPosY or 0.7
+    self.posY = settings.favorHudPosY or 0.62
     self.scale = settings.favorHudScale or 1.0
     self.widthMult = settings.favorHudWidthMult or 1.0
     self:clampPosition()
@@ -1018,4 +1023,16 @@ function NPCFavorHUD:delete()
         self.bgOverlay = nil
     end
 
+end
+
+-- =========================================================
+-- BUILD 17:57 + ATTN 18:02 (hot-reload guide Part 2): force-patch the live
+-- instance after a Ctrl+R reload - mission.npcFavorSystem published in main.lua; holds .favorHUD.
+if g_currentMission ~= nil and g_currentMission.npcFavorSystem ~= nil and g_currentMission.npcFavorSystem.favorHUD ~= nil then
+    local inst = g_currentMission.npcFavorSystem.favorHUD
+    for k, v in pairs(NPCFavorHUD) do
+        if type(v) == "function" then
+            inst[k] = v
+        end
+    end
 end

--- a/src/scripts/NPCFavorHUD.lua
+++ b/src/scripts/NPCFavorHUD.lua
@@ -19,6 +19,11 @@
 NPCFavorHUD = NPCFavorHUD or {}
 NPCFavorHUD_mt = Class(NPCFavorHUD)
 
+local function getBaseGameRenderer()
+    local hud = (g_currentMission ~= nil and g_currentMission.masterHUD) or g_masterHUD
+    return hud ~= nil and hud.renderer or nil
+end
+
 -- =========================================================
 -- Constructor
 -- =========================================================
@@ -31,11 +36,13 @@ function NPCFavorHUD.new(npcSystem)
     -- Position (normalized 0–1, top-left anchor of the HUD box)
     -- BUILD 12:25 (Sam DESIGN 12:23): Active Favors factory default is
     -- Middle-Left-Top in the suite's non-overlap layout. Saved drag XML wins.
-    self.posX = 0.02
-    self.posY = 0.62
+    -- Wizard 2026-08-21: factory home is the suite layout Wizard arranged
+    -- in-game (left column). Saved settings still win on load.
+    self.posX = 0.023125
+    self.posY = 0.714444
 
     -- Scale multiplier applied to all dimensions and text
-    self.scale = 1.0
+    self.scale = 1.178089   -- factory suite layout (Wizard 2026-08-21)
 
     -- Edit/drag state (runtime only, never persisted)
     self.editMode = false
@@ -131,9 +138,9 @@ end
 
 function NPCFavorHUD:loadFromSettings(settings)
     if not settings then return end
-    self.posX = settings.favorHudPosX or 0.02
-    self.posY = settings.favorHudPosY or 0.62
-    self.scale = settings.favorHudScale or 1.0
+    self.posX = settings.favorHudPosX or 0.023125
+    self.posY = settings.favorHudPosY or 0.714444
+    self.scale = settings.favorHudScale or 1.178089
     self.widthMult = settings.favorHudWidthMult or 1.0
     self:clampPosition()
 end
@@ -687,22 +694,25 @@ function NPCFavorHUD:draw()
     local bgY = self.posY - bgH + pad
     local bgW = w + pad * 2
 
-    -- Drop shadow (offset slightly down-right for depth)
-    local shadowOff = 0.002 * s
-    setOverlayColor(self.bgOverlay, self.COLORS.SHADOW[1], self.COLORS.SHADOW[2], self.COLORS.SHADOW[3], self.COLORS.SHADOW[4])
-    renderOverlay(self.bgOverlay, bgX + shadowOff, bgY - shadowOff, bgW, bgH)
+    local renderer = getBaseGameRenderer()
+    local usedNativePanel = renderer ~= nil and renderer.renderPanel ~= nil
+        and renderer:renderPanel(bgX, bgY, bgW, bgH, self.COLORS.BG[4])
+    if not usedNativePanel then
+        -- Standalone fallback: retain the original graph_pixel shadow, fill and border.
+        local shadowOff = 0.002 * s
+        setOverlayColor(self.bgOverlay, self.COLORS.SHADOW[1], self.COLORS.SHADOW[2], self.COLORS.SHADOW[3], self.COLORS.SHADOW[4])
+        renderOverlay(self.bgOverlay, bgX + shadowOff, bgY - shadowOff, bgW, bgH)
 
-    -- Main background fill
-    setOverlayColor(self.bgOverlay, self.COLORS.BG[1], self.COLORS.BG[2], self.COLORS.BG[3], self.COLORS.BG[4])
-    renderOverlay(self.bgOverlay, bgX, bgY, bgW, bgH)
+        setOverlayColor(self.bgOverlay, self.COLORS.BG[1], self.COLORS.BG[2], self.COLORS.BG[3], self.COLORS.BG[4])
+        renderOverlay(self.bgOverlay, bgX, bgY, bgW, bgH)
 
-    -- Permanent subtle border (always visible)
-    local bwNormal = 0.001
-    setOverlayColor(self.bgOverlay, self.COLORS.BORDER_NORMAL[1], self.COLORS.BORDER_NORMAL[2], self.COLORS.BORDER_NORMAL[3], self.COLORS.BORDER_NORMAL[4])
-    renderOverlay(self.bgOverlay, bgX, bgY + bgH - bwNormal, bgW, bwNormal)       -- top
-    renderOverlay(self.bgOverlay, bgX, bgY, bgW, bwNormal)                         -- bottom
-    renderOverlay(self.bgOverlay, bgX, bgY, bwNormal, bgH)                         -- left
-    renderOverlay(self.bgOverlay, bgX + bgW - bwNormal, bgY, bwNormal, bgH)        -- right
+        local bwNormal = 0.001
+        setOverlayColor(self.bgOverlay, self.COLORS.BORDER_NORMAL[1], self.COLORS.BORDER_NORMAL[2], self.COLORS.BORDER_NORMAL[3], self.COLORS.BORDER_NORMAL[4])
+        renderOverlay(self.bgOverlay, bgX, bgY + bgH - bwNormal, bgW, bwNormal)       -- top
+        renderOverlay(self.bgOverlay, bgX, bgY, bgW, bwNormal)                         -- bottom
+        renderOverlay(self.bgOverlay, bgX, bgY, bwNormal, bgH)                         -- left
+        renderOverlay(self.bgOverlay, bgX + bgW - bwNormal, bgY, bwNormal, bgH)        -- right
+    end
 
     -- Edit mode: pulsing border + resize handles
     if self.editMode then
@@ -887,15 +897,21 @@ function NPCFavorHUD:draw()
             -- Progress bar (below line 2, only when progress > 0)
             if favor.progress and favor.progress > 0 then
                 local barWidth = w * 0.6
-                local barHeight = 0.004 * s
+                local barHeight = (6 / 1080) * s
                 local barY = line2Y - 0.007 * s
 
-                setOverlayColor(self.bgOverlay, self.COLORS.BAR_BG[1], self.COLORS.BAR_BG[2], self.COLORS.BAR_BG[3], self.COLORS.BAR_BG[4])
-                renderOverlay(self.bgOverlay, self.posX, barY, barWidth, barHeight)
+                local barColor = {textColor[1], textColor[2], textColor[3], 0.8}
+                local usedNativeBar = renderer ~= nil and renderer.renderProgressBar ~= nil
+                    and renderer:renderProgressBar(self.posX, barY, barWidth, barHeight,
+                        favor.progress / 100, barColor)
+                if not usedNativeBar then
+                    setOverlayColor(self.bgOverlay, self.COLORS.BAR_BG[1], self.COLORS.BAR_BG[2], self.COLORS.BAR_BG[3], self.COLORS.BAR_BG[4])
+                    renderOverlay(self.bgOverlay, self.posX, barY, barWidth, barHeight)
 
-                local progressWidth = barWidth * (favor.progress / 100)
-                setOverlayColor(self.bgOverlay, textColor[1], textColor[2], textColor[3], 0.8)
-                renderOverlay(self.bgOverlay, self.posX, barY, progressWidth, barHeight)
+                    local progressWidth = barWidth * (favor.progress / 100)
+                    setOverlayColor(self.bgOverlay, textColor[1], textColor[2], textColor[3], 0.8)
+                    renderOverlay(self.bgOverlay, self.posX, barY, progressWidth, barHeight)
+                end
 
                 setTextAlignment(RenderText.ALIGN_LEFT)
                 setTextColor(self.COLORS.TEXT_DIM[1], self.COLORS.TEXT_DIM[2], self.COLORS.TEXT_DIM[3], self.COLORS.TEXT_DIM[4])

--- a/src/settings/NPCSettings.lua
+++ b/src/settings/NPCSettings.lua
@@ -58,7 +58,10 @@ function NPCSettings:resetToDefaults()
     self.nameDisplayDistance = 50
     self.notificationDuration = 4000
     self.favorHudPosX = 0.02
-    self.favorHudPosY = 0.7
+    -- BUILD 12:52 (Vera F2): the settings seed must agree with the NPCFavorHUD
+    -- constructor and Sam DESIGN 12:23 - a fresh settings XML seeds 0.62, so the
+    -- missing-sidecar path lands on the suite non-overlap home, not the old 0.7.
+    self.favorHudPosY = 0.62
     self.favorHudScale = 1.0
     self.favorHudLocked = false
     self.favorPanelScale = 1.0

--- a/translations/add_npc_notice_loaded.py
+++ b/translations/add_npc_notice_loaded.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""BUILD 15:39 / PB-14 - add the player-facing startup notice string.
+
+The old startup line was a red blinking warning telling the player to type
+`npcHelp` in the console. It is replaced by a player-language notice on the
+shared MasterHUD notice queue, which needs one new l10n key: npc_notice_loaded.
+
+Translations here are the plain "mod is ready" sentence, carrying the version
+via %s. Languages without a hand-written translation fall back to English
+rather than shipping a machine-mangled sentence; the Lua guards with hasText so
+a missing key can never render as a raw id.
+
+Files are decoded utf-8-sig and written back as plain UTF-8 with no BOM.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+HERE = Path(__file__).resolve().parent
+KEY = "npc_notice_loaded"
+
+EN = "NPC Favor v%s ready. Your neighbours are settling in."
+
+TEXTS = {
+    "en": EN,
+    "de": "NPC Favor v%s bereit. Deine Nachbarn richten sich ein.",
+    "fr": "NPC Favor v%s est prêt. Vos voisins s'installent.",
+    "es": "NPC Favor v%s listo. Tus vecinos se están instalando.",
+    "ea": "NPC Favor v%s listo. Tus vecinos se están instalando.",
+    "it": "NPC Favor v%s pronto. I tuoi vicini si stanno sistemando.",
+    "nl": "NPC Favor v%s is klaar. Je buren richten zich in.",
+    "pl": "NPC Favor v%s gotowy. Twoi sąsiedzi się zadomawiają.",
+    "pt": "NPC Favor v%s pronto. Os seus vizinhos estão a instalar-se.",
+    "br": "NPC Favor v%s pronto. Seus vizinhos estão se instalando.",
+    "ru": "NPC Favor v%s готов. Ваши соседи обживаются.",
+    "uk": "NPC Favor v%s готовий. Ваші сусіди облаштовуються.",
+    "cz": "NPC Favor v%s připraven. Vaši sousedé se zabydlují.",
+    "da": "NPC Favor v%s er klar. Dine naboer falder til.",
+    "no": "NPC Favor v%s er klar. Naboene dine faller til ro.",
+    "sv": "NPC Favor v%s är klart. Dina grannar installerar sig.",
+    "fi": "NPC Favor v%s valmis. Naapurisi asettuvat taloksi.",
+    "hu": "NPC Favor v%s kész. A szomszédaid berendezkednek.",
+    "ro": "NPC Favor v%s gata. Vecinii tăi se instalează.",
+    "tr": "NPC Favor v%s hazır. Komşularınız yerleşiyor.",
+}
+
+
+def read(path):
+    return path.read_bytes().decode("utf-8-sig")
+
+
+def write(path, text):
+    path.write_bytes(text.encode("utf-8"))
+
+
+def main():
+    changed, skipped = [], []
+    files = sorted(HERE.glob("lang_*.xml"))
+    if not files:
+        print("no lang_*.xml found")
+        return 1
+
+    for path in files:
+        lang = path.stem.split("_", 1)[1]
+        body = read(path)
+
+        if 'name="%s"' % KEY in body:
+            skipped.append(path.name)
+            continue
+
+        value = TEXTS.get(lang, EN)
+        # XML-escape the value; the sentences carry no markup but this keeps the
+        # writer honest if one ever gains an ampersand.
+        value = value.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
+        entry = '\t\t<text name="%s" text="%s" />\n' % (KEY, value)
+
+        new = re.sub(r"([ \t]*)</texts>", entry + r"\1</texts>", body, count=1)
+        if new == body:
+            print("could not find </texts> in %s" % path.name)
+            return 1
+        write(path, new)
+        changed.append(path.name)
+
+    print("added %s to %d file(s), %d already had it" % (KEY, len(changed), len(skipped)))
+
+    # Verify: every shipped language file must now carry the key exactly once.
+    bad = []
+    for path in files:
+        n = read(path).count('name="%s"' % KEY)
+        if n != 1:
+            bad.append("%s: %d occurrences" % (path.name, n))
+    if bad:
+        print("VERIFY FAILED:")
+        for b in bad:
+            print("  " + b)
+        return 1
+    print("verified: %s present exactly once in all %d language files" % (KEY, len(files)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/translations/lang_br.xml
+++ b/translations/lang_br.xml
@@ -331,5 +331,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s pronto. Seus vizinhos estão se instalando." />
 </texts>
 </l10n>

--- a/translations/lang_ct.xml
+++ b/translations/lang_ct.xml
@@ -333,5 +333,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s ready. Your neighbours are settling in." />
 </texts>
 </l10n>

--- a/translations/lang_cz.xml
+++ b/translations/lang_cz.xml
@@ -331,5 +331,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s připraven. Vaši sousedé se zabydlují." />
 </texts>
 </l10n>

--- a/translations/lang_da.xml
+++ b/translations/lang_da.xml
@@ -333,5 +333,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s er klar. Dine naboer falder til." />
 </texts>
 </l10n>

--- a/translations/lang_de.xml
+++ b/translations/lang_de.xml
@@ -331,5 +331,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s bereit. Deine Nachbarn richten sich ein." />
 </texts>
 </l10n>

--- a/translations/lang_ea.xml
+++ b/translations/lang_ea.xml
@@ -333,5 +333,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s listo. Tus vecinos se están instalando." />
 </texts>
 </l10n>

--- a/translations/lang_en.xml
+++ b/translations/lang_en.xml
@@ -331,5 +331,6 @@
 		<text name="npc_rf_pda_urg_min" text="&lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s ready. Your neighbours are settling in." />
 </texts>
 </l10n>

--- a/translations/lang_es.xml
+++ b/translations/lang_es.xml
@@ -331,5 +331,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s listo. Tus vecinos se están instalando." />
 </texts>
 </l10n>

--- a/translations/lang_fc.xml
+++ b/translations/lang_fc.xml
@@ -333,5 +333,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s ready. Your neighbours are settling in." />
 </texts>
 </l10n>

--- a/translations/lang_fi.xml
+++ b/translations/lang_fi.xml
@@ -333,5 +333,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s valmis. Naapurisi asettuvat taloksi." />
 </texts>
 </l10n>

--- a/translations/lang_fr.xml
+++ b/translations/lang_fr.xml
@@ -331,5 +331,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s est prêt. Vos voisins s'installent." />
 </texts>
 </l10n>

--- a/translations/lang_hu.xml
+++ b/translations/lang_hu.xml
@@ -333,5 +333,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s kész. A szomszédaid berendezkednek." />
 </texts>
 </l10n>

--- a/translations/lang_id.xml
+++ b/translations/lang_id.xml
@@ -333,5 +333,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s ready. Your neighbours are settling in." />
 </texts>
 </l10n>

--- a/translations/lang_it.xml
+++ b/translations/lang_it.xml
@@ -331,5 +331,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s pronto. I tuoi vicini si stanno sistemando." />
 </texts>
 </l10n>

--- a/translations/lang_jp.xml
+++ b/translations/lang_jp.xml
@@ -333,5 +333,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s ready. Your neighbours are settling in." />
 </texts>
 </l10n>

--- a/translations/lang_kr.xml
+++ b/translations/lang_kr.xml
@@ -333,5 +333,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s ready. Your neighbours are settling in." />
 </texts>
 </l10n>

--- a/translations/lang_nl.xml
+++ b/translations/lang_nl.xml
@@ -333,5 +333,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s is klaar. Je buren richten zich in." />
 </texts>
 </l10n>

--- a/translations/lang_no.xml
+++ b/translations/lang_no.xml
@@ -333,5 +333,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s er klar. Naboene dine faller til ro." />
 </texts>
 </l10n>

--- a/translations/lang_pl.xml
+++ b/translations/lang_pl.xml
@@ -331,5 +331,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s gotowy. Twoi sąsiedzi się zadomawiają." />
 </texts>
 </l10n>

--- a/translations/lang_pt.xml
+++ b/translations/lang_pt.xml
@@ -333,5 +333,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s pronto. Os seus vizinhos estão a instalar-se." />
 </texts>
 </l10n>

--- a/translations/lang_ro.xml
+++ b/translations/lang_ro.xml
@@ -333,5 +333,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s gata. Vecinii tăi se instalează." />
 </texts>
 </l10n>

--- a/translations/lang_ru.xml
+++ b/translations/lang_ru.xml
@@ -331,5 +331,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s готов. Ваши соседи обживаются." />
 </texts>
 </l10n>

--- a/translations/lang_sv.xml
+++ b/translations/lang_sv.xml
@@ -333,5 +333,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s är klart. Dina grannar installerar sig." />
 </texts>
 </l10n>

--- a/translations/lang_tr.xml
+++ b/translations/lang_tr.xml
@@ -333,5 +333,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s hazır. Komşularınız yerleşiyor." />
 </texts>
 </l10n>

--- a/translations/lang_uk.xml
+++ b/translations/lang_uk.xml
@@ -331,5 +331,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s готовий. Ваші сусіди облаштовуються." />
 </texts>
 </l10n>

--- a/translations/lang_vi.xml
+++ b/translations/lang_vi.xml
@@ -333,5 +333,6 @@
 		<text name="npc_rf_pda_urg_min" text="[EN] &lt;1h" />
 		<text name="npc_rf_pda_urg_hot" text="[EN] Urgent" />
 		<text name="npc_rf_pda_urg_warn" text="[EN] Soon" />
+		<text name="npc_notice_loaded" text="NPC Favor v%s ready. Your neighbours are settling in." />
 </texts>
 </l10n>

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -22,9 +22,13 @@
             </ThreePartBitmap>
 
             <Bitmap profile="fs25_subCategoryContainer" id="rfFilterBox">
-                <MultiTextOption profile="fs25_subCategorySelector" id="rfPanelSelector"
-                                 disableButtonsOnSingleText="false"
-                                 onClick="onClickRfPanelSelector" focusInit="onOpen"/>
+                <!-- BUILD 18:16: rfPanelSelector moved to LAST child of rfFilterBox (see below).
+                     George TASK 18:12 asked for z-order ~10-20 on the selector; this engine has no
+                     z attribute of any kind (GuiElement loads none, and no rfHeaderBg element exists
+                     in this page) - draw AND input priority are declaration order, walked in reverse
+                     for events. Declaring the selector last IS the engine's z-raise: it now receives
+                     events before every sibling in this box and draws above them. Positions are
+                     profile-absolute, so nothing moves a pixel. -->
                 <BoxLayout profile="fs25_subCategorySelectorBox" id="rfPanelDotBox">
                     <RoundCorner profile="fs25_subCategorySelectorDot" id="rfPanelDotTemplate"/>
                 </BoxLayout>
@@ -60,6 +64,16 @@
                         <Slider profile="fs25_listSlider" dataElementId="moduleList" hideParentWhenEmpty="true"/>
                     </ThreePartBitmap>
                 </GuiElement>
+
+                <!-- BUILD 18:16 (George TASK 18:12): the module selector is deliberately the LAST
+                     child of rfFilterBox. Events walk children in reverse declaration order, so
+                     last-declared = first offered = this engine's only "z-order raise". Its band
+                     rect (profile-positioned, unchanged) does not overlap any sibling's visible
+                     paint, so drawing on top changes no pixel. The BUILD 17:08 page-level click
+                     shield stays as the guarantee against anything OUTSIDE this box. -->
+                <MultiTextOption profile="fs25_subCategorySelector" id="rfPanelSelector"
+                                 disableButtonsOnSingleText="false"
+                                 onClick="onClickRfPanelSelector" focusInit="onOpen"/>
             </Bitmap>
 
             <!-- WC page chrome: sibling under Modules (NOT inside rfFilterBox — hit hygiene).
@@ -222,29 +236,43 @@
                              built by whichever mod loads first, from its own copy, so a change
                              in Soil alone would be overwritten by whoever won the race. -->
                         <GuiElement profile="RF_EscCardFrame" id="treatProductsShell" position="220px -22px" size="620px 248px">
-                            <Text profile="RF_TreatSelected" id="treatSelectedLabel" position="10px -6px" size="600px 20px"
+                            <!-- BUILD 09:19 (PB-05). Brian read "Wait: amending now can burn t..." on
+                                 this strip: the sentence that says an apply will scorch the crop was
+                                 cut before its own verb.
+                                 The wrap was not broken. TextElement defaults to LAYOUT_MODE.TRUNCATE
+                                 (TextElement.lua:141) and with textMaxNumLines > 1 that takes the
+                                 limitVerticalLines path (:667-676), wrapping at absSize[1] and then
+                                 chopping characters until the text fits the line budget before adding
+                                 "..." (:679-699). So it wrapped to its two lines exactly as asked and
+                                 the string is simply longer than two lines of 18px across 600px.
+                                 Two allowed 18px lines become three. The 18px comes out of this zone
+                                 rather than out of the table: Selected moves up 2, the hairline and
+                                 the PRODUCTS heading close up, and the eight-row clip drops 4. Row 8
+                                 still ends 4px clear of the card frame (124 + 120 = 244 against 248),
+                                 so nothing is cut mid-glyph and the card does not grow. -->
+                            <Text profile="RF_TreatSelected" id="treatSelectedLabel" position="10px -4px" size="600px 20px"
                                   textAlignment="left"/>
-                            <Text profile="RF_TreatNext" id="treatNextLabel" position="10px -26px" size="600px 36px"
-                                  textAlignment="left" textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <!-- Zone split (BUILD 16:19): Selected + Next stay on top, then ~16px of
-                                 air with one 1px hairline centred in it, then the PRODUCTS table.
+                            <Text profile="RF_TreatNext" id="treatNextLabel" position="10px -24px" size="600px 54px"
+                                  textAlignment="left" textMaxNumLines="3" textVerticalAlignment="top"/>
+                            <!-- Zone split (BUILD 16:19): Selected + Next stay on top, then air with
+                                 one 1px hairline in it, then the PRODUCTS table.
                                  One outer outline only; the rule is a Bitmap, not a second frame.
                                  Bodies inset X 0 -> 10 and widths 560 -> 540 so nothing kisses the
                                  white stroke on either side. -->
-                            <Bitmap profile="RF_EscCardRule" id="treatProductsRule" position="10px -70px" size="600px 1px"/>
-                            <Text profile="RF_ProductsTitle" id="soilTreatProducts" position="10px -80px" size="600px 18px"
+                            <Bitmap profile="RF_EscCardRule" id="treatProductsRule" position="10px -82px" size="600px 1px"/>
+                            <Text profile="RF_ProductsTitle" id="soilTreatProducts" position="10px -86px" size="600px 18px"
                                   text="$l10n_rf_pda_treat_products"/>
-                            <Text profile="RF_ProductColHeaderDense" position="10px -100px" size="40px 16px" text="NUT"/>
-                            <Text profile="RF_ProductColHeaderDense" position="54px -100px" size="270px 16px" text="PRODUCT"/>
-                            <Text profile="RF_ProductColHeaderDense" position="330px -100px" size="100px 16px"
+                            <Text profile="RF_ProductColHeaderDense" position="10px -106px" size="40px 16px" text="NUT"/>
+                            <Text profile="RF_ProductColHeaderDense" position="54px -106px" size="270px 16px" text="PRODUCT"/>
+                            <Text profile="RF_ProductColHeaderDense" position="330px -106px" size="100px 16px"
                                   textAlignment="right" text="RATE"/>
-                            <Text profile="RF_ProductColHeaderDense" position="440px -100px" size="110px 16px"
+                            <Text profile="RF_ProductColHeaderDense" position="440px -106px" size="110px 16px"
                                   textAlignment="right" text="TOTAL"/>
-                            <Text profile="RF_ProductOk" id="treatPlanLines" position="10px -120px" size="600px 22px"
+                            <Text profile="RF_ProductOk" id="treatPlanLines" position="10px -124px" size="600px 22px"
                                   visible="false"/>
                             <!-- Clip sized to exactly the eight densified rows (8 x 15 = 120), so the
-                                 card bottom keeps 8px of air instead of cutting row 8 mid-glyph. -->
-                            <GuiElement profile="RF_ProductsRowsClip" id="treatProdRowsClip" position="10px -120px" size="600px 120px">
+                                 card bottom keeps air instead of cutting row 8 mid-glyph. -->
+                            <GuiElement profile="RF_ProductsRowsClip" id="treatProdRowsClip" position="10px -124px" size="600px 120px">
                                 <GuiElement profile="RF_ProductRow" id="treatProdRow1" position="0px 0px" size="600px 15px" visible="false">
                                     <Text profile="RF_ProductCellDense" id="treatProd1Nut" position="0px 0px" size="40px 15px"/>
                                     <Text profile="RF_ProductCellDense" id="treatProd1Name" position="44px 0px" size="270px 15px"/>
@@ -312,20 +340,43 @@
                             <Text profile="RF_ProductCell" id="soilRotationStatus" position="10px -56px" size="270px 20px"/>
                             <Text profile="RF_ProductCell" id="soilRotationTip" position="10px -76px" size="270px 32px"
                                   textMaxNumLines="2" textVerticalAlignment="top"/>
-                            <Bitmap profile="RF_EscCardRule" id="soilRotationRule" position="10px -116px" size="270px 1px"/>
-                            <Text profile="RF_ProductColHeader" id="soilRotationWhatIfHeader" position="10px -124px" size="270px 16px"/>
-                            <Text profile="RF_ProductColHeader" id="soilRotationIfColCrop" position="10px -144px" size="92px 14px"/>
-                            <Text profile="RF_ProductColHeader" id="soilRotationIfColStatus" position="106px -144px" size="60px 14px"/>
-                            <Text profile="RF_ProductColHeader" id="soilRotationIfColEffect" position="170px -144px" size="110px 14px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf1Crop" position="10px -162px" size="92px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf1Status" position="106px -162px" size="60px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf1Effect" position="170px -162px" size="110px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf2Crop" position="10px -184px" size="92px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf2Status" position="106px -184px" size="60px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf2Effect" position="170px -184px" size="110px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf3Crop" position="10px -206px" size="92px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf3Status" position="106px -206px" size="60px 18px"/>
-                            <Text profile="RF_ProductCell" id="soilRotationIf3Effect" position="170px -206px" size="110px 18px"/>
+                            <!-- BUILD 09:19 (PB-05). The WHAT IF effect column lost whole consequences.
+                                 RotationPlannerData.effectText joins at most three items with ", " and
+                                 the set is closed: fatigue "x1.15 depletion", nitrogen "+N", and one of
+                                 "less disease" / "more disease". The worst real string is therefore
+                                 "x1.15 depletion, +N, less disease" at 33 characters, and the painter
+                                 capped the cell at 18 - so even the two-item "x1.15 depletion, +N" (19)
+                                 dropped an item and the player was told about the fatigue but not about
+                                 the disease.
+                                 18 was not arbitrary against the OLD cell: this card's own calibration
+                                 is ~6px per glyph at 17px (crop 92px/16, status 60px/10, effect 110px/18),
+                                 so 110px really does hold about 18. One 17px line cannot hold 33 and the
+                                 card cannot grow - George holds the footprint at 290x248 and it must
+                                 never take width back from PRODUCTS. So the effect cell gains a SECOND
+                                 line at 14px instead, which is the size the PRODUCTS table already uses
+                                 for its own cells (RF_ProductCellDense), and about 22 glyphs a line at
+                                 that size gives ~44 against a bounded worst case of 33.
+                                 Row pitch 22 -> 30 to hold the taller cell; the hairline and the two
+                                 header lines close up by 4-8px to pay for it. Row 3 ends at 240 against
+                                 the 248 frame, so the card keeps its 8px of bottom air. Crop and Status
+                                 stay one 17px line and are unchanged. -->
+                            <Bitmap profile="RF_EscCardRule" id="soilRotationRule" position="10px -112px" size="270px 1px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationWhatIfHeader" position="10px -118px" size="270px 16px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationIfColCrop" position="10px -136px" size="92px 14px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationIfColStatus" position="106px -136px" size="60px 14px"/>
+                            <Text profile="RF_ProductColHeader" id="soilRotationIfColEffect" position="170px -136px" size="110px 14px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf1Crop" position="10px -152px" size="92px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf1Status" position="106px -152px" size="60px 18px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilRotationIf1Effect" position="170px -152px" size="110px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf2Crop" position="10px -182px" size="92px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf2Status" position="106px -182px" size="60px 18px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilRotationIf2Effect" position="170px -182px" size="110px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf3Crop" position="10px -212px" size="92px 18px"/>
+                            <Text profile="RF_ProductCell" id="soilRotationIf3Status" position="106px -212px" size="60px 18px"/>
+                            <Text profile="RF_ProductCellEffect" id="soilRotationIf3Effect" position="170px -212px" size="110px 28px"
+                                  textMaxNumLines="2" textVerticalAlignment="top"/>
                         </GuiElement>
 
                         <!-- Col 3: sampling — shifted right so widened PRODUCTS does not overlap -->
@@ -526,6 +577,19 @@
                             <Text profile="RF_TreatTargetLine" id="rfFwRow8C" position="610px -264px" size="220px 20px" text=""/>
                             <Text profile="RF_TreatTargetLine" id="rfFwRow8D" position="850px -264px" size="280px 20px" text=""/>
                             <Text profile="RF_TreatTargetLine" id="rfFwMore" position="10px -300px" size="1120px 20px" text=""/>
+                            <!-- BUILD 09:19 (PB-07): row pager for this static eight-row table.
+                                 Hidden by default and shown ONLY by a guest that implements
+                                 onPageStep, so Income / Dairy / Depot keep exactly the page they
+                                 have today. Two Buttons, not a SmoothList: George's standing NO-GO
+                                 on nesting a SmoothList in this page (see csConsultPanel below)
+                                 applies here too, and a window offset held by the guest cannot
+                                 re-enter the layout the way a list rebuild can.
+                                 Parked on the rfFwTableTitle band, which every Table-mode guest
+                                 already hides, so the pager collides with nothing that paints. -->
+                            <Button profile="buttonActivate" id="rfFwPagePrev" position="880px -8px" size="120px 24px"
+                                    visible="false" text="" onClick="onClickRfFwPagePrev"/>
+                            <Button profile="buttonActivate" id="rfFwPageNext" position="1010px -8px" size="120px 24px"
+                                    visible="false" text="" onClick="onClickRfFwPageNext"/>
                             <Text profile="RF_HintText" id="rfFwEmptyHint" position="10px -68px" size="1120px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
                             <Text profile="RF_HintText" id="rfFwHintTable" position="10px -336px" size="1120px 80px"

--- a/xml/gui/rfEscProfiles.xml
+++ b/xml/gui/rfEscProfiles.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <GUIProfiles>
     <!-- ============================================================ -->
     <!-- Realistic Farming PDA profiles — MOCKUP-ESC-RF-PDA swatches  -->
@@ -260,6 +260,16 @@
     </Profile>
     <Profile name="RF_ProductCellRight" extends="RF_ProductCell">
         <textAlignment value="right"/>
+    </Profile>
+    <!-- BUILD 09:19 (PB-05): WHAT IF effect cell only. Two lines at the same 14px the
+         PRODUCTS table already uses for its own cells, so a comma-joined consequence is
+         printed whole instead of losing its last item to a one-line 110px column. Top
+         aligned because a two-line cell that centres would not line up with the one-line
+         Crop and Status cells beside it. -->
+    <Profile name="RF_ProductCellEffect" extends="RF_ProductCell">
+        <textSize value="14px"/>
+        <textMaxNumLines value="2"/>
+        <textVerticalAlignment value="top"/>
     </Profile>
     <Profile name="RF_ProductOk" extends="fs25_textDefault" with="anchorTopLeft">
         <textSize value="18px"/>


### PR DESCRIPTION
## Summary
- Upgrades NPC Favor HUD to native base-game extension styling.
- Integrates full corner scale and left/right edge width resizing.
- Sets factory layout default to (0.023, 0.714, scale 1.178).
- Supports MasterHUD global toggle and edit mode.

## Test plan
- Verified in-game: NPC Favor panel draws with clean base-game look and unified edit controls.