### PR TITLE
fix: hot-reload conformance, suite-edit/vehicle input, docs truth (2026-08-22)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The mod supports singleplayer and multiplayer (not yet tested) , saves all NPC d
 ## 🎮 Quick Start
 
 1. **NPCs spawn automatically.** After the map loads, NPCs appear near buildings around the map. You'll see a console message confirming initialization.
-2. **Look for the [E] prompt.** Walk near an NPC and a contextual prompt appears: "Talk to [NPC Name]". Press **E** to open the dialog.
+2. **Look for the talk prompt.** Walk near an NPC and a contextual prompt appears: "Talk to [NPC Name]" with the key the game has assigned to *Talk to NPC* (assign your own under Options > Controls > Mods). Press it to open the dialog.
 3. **Start a conversation.** The dialog shows the NPC's name, your relationship level, and a greeting that reflects how well they know you.
 4. **Choose an action.** Talk, Ask About Work, Ask for Favor, Give Gift, or view Relationship Info.
 5. **Build the relationship.** Chat regularly, complete favors when available (at relationship 25+), and give gifts (at relationship 30+).

--- a/main.lua
+++ b/main.lua
@@ -46,8 +46,15 @@
 -- =========================================================
 
 -- Add version tracking
-local modDirectory = g_currentModDirectory
-local modName = g_currentModName
+-- Hot-reload latch (FuelCosts reference): g_currentModDirectory and
+-- g_currentModName are nil on a live re-source, so they are latched into
+-- module globals on first load, with a g_modsDirectory loose-folder fallback.
+NPCFavorModDirectory = NPCFavorModDirectory
+    or g_currentModDirectory
+    or (g_modsDirectory ~= nil and (g_modsDirectory .. "FS25_NPCFavor/") or nil)
+NPCFavorModName = NPCFavorModName or g_currentModName or "FS25_NPCFavor"
+local modDirectory = NPCFavorModDirectory
+local modName = NPCFavorModName
 
 local modItem = g_modManager:getModByName(modName)
 local modVersion = modItem.version
@@ -110,11 +117,11 @@ if modDirectory then
     source(modDirectory .. "src/integrations/NPCSettingsHubBridge.lua")
 
 -- Esc RF PDA framework joiner (NO-HOST).
-source(g_currentModDirectory .. "src/gui/RfEscModules.lua")
-source(g_currentModDirectory .. "src/gui/RfPdaMenuPage.lua")
-source(g_currentModDirectory .. "src/gui/RfEscBootstrap.lua")
-source(g_currentModDirectory .. "src/gui/RfEscUiDebugger.lua")
-source(g_currentModDirectory .. "src/gui/NpcRfPdaGuest.lua")
+source((NPCFavorModDirectory or g_currentModDirectory) .. "src/gui/RfEscModules.lua")
+source((NPCFavorModDirectory or g_currentModDirectory) .. "src/gui/RfPdaMenuPage.lua")
+source((NPCFavorModDirectory or g_currentModDirectory) .. "src/gui/RfEscBootstrap.lua")
+source((NPCFavorModDirectory or g_currentModDirectory) .. "src/gui/RfEscUiDebugger.lua")
+source((NPCFavorModDirectory or g_currentModDirectory) .. "src/gui/NpcRfPdaGuest.lua")
 
     print("[NPC Favor] All files loaded successfully")
 else
@@ -634,12 +641,10 @@ if FSBaseMission and FSBaseMission.update then
             end
         end
 
-        -- Auto-exit HUD edit mode if player enters a vehicle
-        if npcSystem.favorHUD and npcSystem.favorHUD.editMode then
-            if g_localPlayer and g_localPlayer.getIsInVehicle and g_localPlayer:getIsInVehicle() then
-                npcSystem.favorHUD:exitEditMode()
-            end
-        end
+        -- 2026-08-22 (Wizard): the old "auto-exit HUD edit when the player is in a
+        -- vehicle" rule is GONE. HUD edit must work in and out of a cab, and with
+        -- MasterHUD suite edit it killed the favor HUD's edit one frame after the
+        -- suite entered it (log: enabled 18:45:07.588, disabled .599).
     end)
 end
 

--- a/src/NPCSystem.lua
+++ b/src/NPCSystem.lua
@@ -145,7 +145,7 @@
 --   converts to seconds (dt = dt / 1000) before passing to subsystems.
 -- =========================================================
 
-NPCSystem = {}
+NPCSystem = NPCSystem or {}
 NPCSystem_mt = Class(NPCSystem)
 
 --- Create a new NPCSystem coordinator.

--- a/src/events/NPCInteractionEvent.lua
+++ b/src/events/NPCInteractionEvent.lua
@@ -38,7 +38,7 @@
            NaN/infinity checks, rate limiting via cooldown.
 ]]
 
-NPCInteractionEvent = {}
+NPCInteractionEvent = NPCInteractionEvent or {}
 local NPCInteractionEvent_mt = Class(NPCInteractionEvent, Event)
 
 InitEventClass(NPCInteractionEvent, "NPCInteractionEvent")

--- a/src/events/NPCSettingsSyncEvent.lua
+++ b/src/events/NPCSettingsSyncEvent.lua
@@ -42,7 +42,7 @@
            string truncation, fail-secure rejection.
 ]]
 
-NPCSettingsSyncEvent = {}
+NPCSettingsSyncEvent = NPCSettingsSyncEvent or {}
 local NPCSettingsSyncEvent_mt = Class(NPCSettingsSyncEvent, Event)
 
 InitEventClass(NPCSettingsSyncEvent, "NPCSettingsSyncEvent")

--- a/src/events/NPCStateSyncEvent.lua
+++ b/src/events/NPCStateSyncEvent.lua
@@ -34,7 +34,7 @@
            client-only execution gate, string truncation.
 ]]
 
-NPCStateSyncEvent = {}
+NPCStateSyncEvent = NPCStateSyncEvent or {}
 local NPCStateSyncEvent_mt = Class(NPCStateSyncEvent, Event)
 
 InitEventClass(NPCStateSyncEvent, "NPCStateSyncEvent")

--- a/src/gui/DialogLoader.lua
+++ b/src/gui/DialogLoader.lua
@@ -10,7 +10,7 @@
 --   DialogLoader.close("MyDialog")
 -- =========================================================
 
-DialogLoader = {}
+DialogLoader = DialogLoader or {}
 
 -- Registry: name -> { class, xmlPath, instance, loaded }
 DialogLoader.dialogs = {}

--- a/src/gui/NPCAdminEditDialog.lua
+++ b/src/gui/NPCAdminEditDialog.lua
@@ -8,7 +8,7 @@
 -- Opened from NPCAdminListDialog when user clicks "Edit".
 -- =========================================================
 
-NPCAdminEditDialog = {}
+NPCAdminEditDialog = NPCAdminEditDialog or {}
 local NPCAdminEditDialog_mt = Class(NPCAdminEditDialog, MessageDialog)
 
 -- Hover color constants

--- a/src/gui/NPCAdminListDialog.lua
+++ b/src/gui/NPCAdminListDialog.lua
@@ -9,7 +9,7 @@
 -- 12 data rows with 3-layer Edit buttons and hover effects.
 -- =========================================================
 
-NPCAdminListDialog = {}
+NPCAdminListDialog = NPCAdminListDialog or {}
 local NPCAdminListDialog_mt = Class(NPCAdminListDialog, MessageDialog)
 
 NPCAdminListDialog.MAX_ROWS = 12

--- a/src/gui/NPCDialog.lua
+++ b/src/gui/NPCDialog.lua
@@ -51,12 +51,12 @@
 -- Opened via NPCFavorGUI → DialogLoader pattern.
 -- =========================================================
 
-NPCDialog = {}
+NPCDialog = NPCDialog or {}
 local NPCDialog_mt = Class(NPCDialog, MessageDialog)
 
 -- Mod-scoped i18n with Missing-reject (same class as MDMUtil.getModText).
 -- Giants g_i18n:getText returns a truthy "Missing '…'" banner on miss; never paint that.
-local NPC_DIALOG_MOD_NAME = g_currentModName
+local NPC_DIALOG_MOD_NAME = (NPCFavorModName or g_currentModName)
 local function getModText(key, fallback)
     if key == nil or key == "" then
         return fallback

--- a/src/gui/NPCFavorManagementDialog.lua
+++ b/src/gui/NPCFavorManagementDialog.lua
@@ -6,7 +6,7 @@
 -- Modeled after NPCListDialog for FS25 compatibility
 -- =========================================================
 
-NPCFavorManagementDialog = {}
+NPCFavorManagementDialog = NPCFavorManagementDialog or {}
 local NPCFavorManagementDialog_mt = Class(NPCFavorManagementDialog, MessageDialog)
 
 NPCFavorManagementDialog.MAX_FAVORS = 5  -- Max visible favors

--- a/src/gui/NPCListDialog.lua
+++ b/src/gui/NPCListDialog.lua
@@ -8,7 +8,7 @@
 -- Shown via: DialogLoader.show("NPCListDialog", "setNPCSystem", g_NPCSystem)
 -- =========================================================
 
-NPCListDialog = {}
+NPCListDialog = NPCListDialog or {}
 local NPCListDialog_mt = Class(NPCListDialog, MessageDialog)
 
 NPCListDialog.MAX_ROWS = 16

--- a/src/gui/NpcRfPdaGuest.lua
+++ b/src/gui/NpcRfPdaGuest.lua
@@ -4,10 +4,10 @@
 -- Active favors → rfFwMore bridge. Read-only glance; spoiler ban held.
 -- =========================================================
 
-NpcRfPdaGuest = {}
+NpcRfPdaGuest = NpcRfPdaGuest or {}
 
-local MOD_DIR = g_currentModDirectory
-local MOD_NAME = g_currentModName
+local MOD_DIR = (NPCFavorModDirectory or g_currentModDirectory)
+local MOD_NAME = (NPCFavorModName or g_currentModName)
 local PANEL_ID = "npcFavor"
 local PANEL_ORDER = 80
 local MAX_ROWS = 8
@@ -577,6 +577,20 @@ local function restoreFwEmptyHintBox(container)
     end
 end
 
+local function stripButtonGlyph(btn)
+    if btn == nil then return end
+    btn.inputActionName = nil
+    btn.keyDisplayText = nil
+    btn.keyOverlay = nil
+    btn.hideKeyboardGlyph = true
+    btn.hasLoadedInputGlyph = false
+    btn.isKeyboardMode = false
+    btn.keyGlyphOffsetX = 0
+    btn.keyGlyphSize = { 0, 0 }
+    btn.iconSize = { 0, 0 }
+    btn.icon = {}
+end
+
 --- BUILD 09:19 (PB-07): show and label the two shared row-pager Buttons.
 ---
 --- The host hides both on every refresh before the guest paints (see _syncHostGuestChrome),
@@ -592,6 +606,9 @@ local function paintPager(container, rosterN, pages)
     local nextEl = findDescendant(container, "rfFwPageNext")
     local multi = rosterN > MAX_ROWS and pages > 1
 
+    stripButtonGlyph(prevEl)
+    stripButtonGlyph(nextEl)
+
     for _, el in ipairs({ prevEl, nextEl }) do
         if el ~= nil then
             if type(el.setVisible) == "function" then el:setVisible(multi) end
@@ -604,10 +621,12 @@ local function paintPager(container, rosterN, pages)
 
     if prevEl ~= nil and type(prevEl.setText) == "function" then
         prevEl:setText(tr("npc_rf_pda_page_prev", "< Back"))
+        stripButtonGlyph(prevEl)
     end
     if nextEl ~= nil and type(nextEl.setText) == "function" then
         nextEl:setText(string.format(
             tr("npc_rf_pda_page_next", "More (%d/%d) >"), _pageIndex, pages))
+        stripButtonGlyph(nextEl)
     end
 end
 

--- a/src/gui/RfEscBootstrap.lua
+++ b/src/gui/RfEscBootstrap.lua
@@ -5,7 +5,7 @@
 -- No Soil privilege; no rfPdaHost. Option B equal-bootstrap path.
 -- =========================================================
 
-RfEscBootstrap = {}
+RfEscBootstrap = RfEscBootstrap or {}
 
 local PAGE_NAME = "menuRealisticFarming"
 local CLASS_NAME = "RfPdaMenuPage"
@@ -105,7 +105,7 @@ local function addIngameMenuPage(frame, pageName, iconPath, uvs, position, predi
 end
 
 --- Ensure shared Esc door exists. Idempotent: skip create if already present.
----@param modDir string g_currentModDirectory of the calling joiner
+---@param modDir string (NPCFavorModDirectory or g_currentModDirectory) of the calling joiner
 ---@param opts table|nil { profilesXml?, iconPath?, uvs? }
 ---@return boolean true if door exists after call
 function RfEscBootstrap.ensureDoor(modDir, opts)

--- a/src/gui/RfEscModules.lua
+++ b/src/gui/RfEscModules.lua
@@ -9,7 +9,7 @@
 -- lottery is NOT the product default.
 -- =========================================================
 
-RfEscModules = {}
+RfEscModules = RfEscModules or {}
 local RfEscModules_mt = Class(RfEscModules)
 
 local HUB_MOD_ID = "RfEsc"

--- a/src/gui/RfEscUiDebugger.lua
+++ b/src/gui/RfEscUiDebugger.lua
@@ -12,7 +12,7 @@
 -- Singleton: only one mod installs (prefer Soil; else first).
 -- =========================================================
 
-RfEscUiDebugger = {}
+RfEscUiDebugger = RfEscUiDebugger or {}
 
 local PAGE_NAME = "menuRealisticFarming"
 local CLASS_NAME = "RfPdaMenuPage"
@@ -65,8 +65,8 @@ local function _getSoilModDirectory()
             return d
         end
     end
-    if g_currentModName == SOIL_MOD_NAME and g_currentModDirectory ~= nil then
-        return g_currentModDirectory
+    if (NPCFavorModName or g_currentModName) == SOIL_MOD_NAME and (NPCFavorModDirectory or g_currentModDirectory) ~= nil then
+        return (NPCFavorModDirectory or g_currentModDirectory)
     end
     if g_modManager ~= nil and type(g_modManager.getModByName) == "function" then
         local ok, mod = pcall(function()
@@ -103,8 +103,8 @@ local function _getXmlPath()
     if RfPdaMenuPage ~= nil and type(RfPdaMenuPage.getXmlFilename) == "function" then
         return RfPdaMenuPage.getXmlFilename()
     end
-    if g_currentModDirectory ~= nil then
-        return g_currentModDirectory .. "xml/gui/" .. CLASS_NAME .. ".xml"
+    if (NPCFavorModDirectory or g_currentModDirectory) ~= nil then
+        return (NPCFavorModDirectory or g_currentModDirectory) .. "xml/gui/" .. CLASS_NAME .. ".xml"
     end
     return nil
 end
@@ -133,7 +133,7 @@ local function _getProfilesXml()
     if fromSoil ~= nil then
         return fromSoil
     end
-    return _profilesCandidate(g_currentModDirectory)
+    return _profilesCandidate((NPCFavorModDirectory or g_currentModDirectory))
 end
 
 local function _captureActiveModuleId()
@@ -707,7 +707,7 @@ function RfEscUiDebugger.install()
 
     -- Prefer Soil when present so non-Soil mods hard no-op even if they source first.
     local soilDir = _getSoilModDirectory()
-    local myDir = g_currentModDirectory
+    local myDir = (NPCFavorModDirectory or g_currentModDirectory)
     if soilDir ~= nil and myDir ~= nil and _normDir(soilDir) ~= _normDir(myDir) then
         return
     end
@@ -719,7 +719,7 @@ function RfEscUiDebugger.install()
     end
     _listenerInstalled = true
     _markInstalledGlobally()
-    local owner = (g_currentModName ~= nil and g_currentModName) or "unknown"
+    local owner = ((NPCFavorModName or g_currentModName) ~= nil and (NPCFavorModName or g_currentModName)) or "unknown"
     _log("info", "installed by %s (F6 / rfEscReloadGui). Dev-only; frame-replace path; not Vera F1 substitute.", tostring(owner))
 end
 

--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -13,8 +13,8 @@
 -- SoilPDAScreen coexists untouched.
 -- =========================================================
 
-local MOD_DIR = g_currentModDirectory
-local MOD_NAME = g_currentModName
+local MOD_DIR = (SeasonalCropStressModDirectory or g_currentModDirectory)
+local MOD_NAME = (SeasonalCropStressModName or g_currentModName)
 
 -- Soft log when sourced from a non-Soil joiner (SoilLogger may be absent).
 -- BUILD 17:08: the stub's signature must match Soil's real logger, which is DOT-called
@@ -44,7 +44,7 @@ if SoilLogger == nil then
 end
 
 ---@class RfPdaMenuPage
-RfPdaMenuPage = {}
+RfPdaMenuPage = RfPdaMenuPage or {}
 RfPdaMenuPage.CLASS_NAME = "RfPdaMenuPage"
 -- NO-HOST: shared Esc door name (not Soil-owned menuSoilFertilizer).
 RfPdaMenuPage.MENU_PAGE_NAME = "menuRealisticFarming"
@@ -199,7 +199,7 @@ local function mdResolve(bare, name)
     end
     -- 2. the named environment. Kept first among the fallbacks because it is the cheapest
     --    and correct in the common case, but NOT trusted alone - this hardcodes a mod name
-    --    the guest itself never hardcodes (it uses g_currentModName), so a rename or a
+    --    the guest itself never hardcodes (it uses (SeasonalCropStressModName or g_currentModName)), so a rename or a
     --    differently-named install slips straight past it. That is what produced
     --    "GATE graph=false" on the Dairy door.
     if g_modEnvironments ~= nil then
@@ -1632,8 +1632,20 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     -- exist and would never have hidden them.
     for _, id in ipairs({ "rfFwPagePrev", "rfFwPageNext" }) do
         local btn = self:getDescendantById(id)
-        if btn ~= nil and type(btn.setVisible) == "function" then
-            btn:setVisible(false)
+        if btn ~= nil then
+            btn.inputActionName = nil
+            btn.keyDisplayText = nil
+            btn.keyOverlay = nil
+            btn.hideKeyboardGlyph = true
+            btn.hasLoadedInputGlyph = false
+            btn.isKeyboardMode = false
+            btn.keyGlyphOffsetX = 0
+            btn.keyGlyphSize = { 0, 0 }
+            btn.iconSize = { 0, 0 }
+            btn.icon = {}
+            if type(btn.setVisible) == "function" then
+                btn:setVisible(false)
+            end
         end
     end
     -- Action bar rides the CS module only; the guest decides the two buttons.
@@ -2497,19 +2509,24 @@ function RfPdaMenuPage:onClickRfFwPageNext()
     self:_rfFwPageStep(1)
 end
 
---- BUILD 14:04 (PB-07): Space and ">" advance the row pager, per the brief's
---- "click/Space/>" acceptance. keyEvent walks children first via the superclass
---- (GuiElement.lua:772-784, children in reverse order, eventUsed carried), so a focused
---- control that consumes the key - including the pager Button itself activating on Space -
---- wins before this fires and nothing double-steps. Only an unclaimed press reaches the
---- step, and only a step that actually moved marks the event used; on every page without a
---- pageable guest _rfFwPageStep returns false immediately and the key passes through
---- untouched. unicode 32 is Space, 62 is ">", taken from the event's own unicode so the
---- layout that produced ">" does not matter.
+--- 2026-08-22 (Wizard): pager keys are now . / > for next and , / < for back
+--- (Space is retired - it collided with the engine's global button-activate and its
+--- glyph chip was what overlapped the labels; the buttons themselves now use the
+--- glyph-hidden RF_CsPivotBtn profile). keyEvent walks children first via the
+--- superclass (GuiElement.lua:772-784, children in reverse order, eventUsed carried),
+--- so a focused control that consumes the key wins before this fires and nothing
+--- double-steps. Only an unclaimed press reaches the step, and only a step that
+--- actually moved marks the event used; on every page without a pageable guest
+--- _rfFwPageStep returns false immediately and the key passes through untouched.
+--- unicode 46 is ".", 62 is ">", 44 is ",", 60 is "<" - taken from the event's own
+--- unicode so keyboard layout does not matter.
 function RfPdaMenuPage:keyEvent(unicode, sym, modifier, isDown, eventUsed)
     local used = RfPdaMenuPage:superClass().keyEvent(self, unicode, sym, modifier, isDown, eventUsed)
-    if not used and isDown == true and (unicode == 32 or unicode == 62) then
+    if not used and isDown == true and (unicode == 46 or unicode == 62) then
         used = self:_rfFwPageStep(1) == true
+    end
+    if not used and isDown == true and (unicode == 44 or unicode == 60) then
+        used = self:_rfFwPageStep(-1) == true
     end
     return used
 end

--- a/src/integrations/NPCMasterHUDBridge.lua
+++ b/src/integrations/NPCMasterHUDBridge.lua
@@ -30,10 +30,10 @@
 -- independent and happens at Mission00.loadMission00Finished.
 -- =========================================================
 
-NPCMasterHUDBridge = {}
+NPCMasterHUDBridge = NPCMasterHUDBridge or {}
 
 NPCMasterHUDBridge.HUD_ID = "NPCFavor_HUD"
-NPCMasterHUDBridge.active = false   -- MasterHUD present and we registered
+NPCMasterHUDBridge.active = NPCMasterHUDBridge.active or false   -- survives reload; register() re-derives it
 
 -- The NPC HUD draw body. Resolves the system from the canonical global so it can be
 -- driven either by MasterHUD or by NPCFavor's own FSBaseMission.draw hook. NPCSystem:draw
@@ -80,7 +80,10 @@ function NPCMasterHUDBridge.register()
                     local sys = g_NPCSystem
                     if sys ~= nil and sys.favorHUD ~= nil and sys.favorHUD.editMode
                         and sys.favorHUD.exitEditMode ~= nil then
+                        -- suite-owned exit: the HUD ignores every other exit while suite edit is ON
+                        sys.favorHUD._suiteExiting = true
                         sys.favorHUD:exitEditMode()
+                        sys.favorHUD._suiteExiting = false
                     end
                 end,
             })
@@ -88,4 +91,16 @@ function NPCMasterHUDBridge.register()
     else
         print(string.format("[NPC Favor] MasterHUD registration failed: %s (using own draw hook)", tostring(err)))
     end
+end
+
+-- =========================================================
+-- Hot-reload delivery (2026-08-22): register() only runs at mission load, so a
+-- push of this file alone would define the new listener without registering it.
+-- NOT gated on .active (the gated shape skips silently when the boot-time bridge
+-- predates the flag). register() is idempotent - subscribe and
+-- registerEditListener both replace by id - so every live source pass may fire it;
+-- on a cold pass the mission handle does not exist yet and this is a no-op.
+local __hud = (g_currentMission ~= nil and g_currentMission.masterHUD) or g_masterHUD
+if __hud ~= nil then
+    pcall(function() NPCMasterHUDBridge.register() end)
 end

--- a/src/integrations/NPCNetworkSyncBridge.lua
+++ b/src/integrations/NPCNetworkSyncBridge.lua
@@ -32,7 +32,7 @@
 -- The cross-mod handle is g_currentMission.networkSync. Registration is order independent.
 -- =========================================================
 
-NPCNetworkSyncBridge = {}
+NPCNetworkSyncBridge = NPCNetworkSyncBridge or {}
 
 -- Locked network channel / module id. Never renamed (a later rename desyncs a mixed lobby).
 NPCNetworkSyncBridge.MODULE_ID = "NPCFavor_Sync"

--- a/src/integrations/NPCSettingsHubBridge.lua
+++ b/src/integrations/NPCSettingsHubBridge.lua
@@ -29,7 +29,7 @@
 -- independent, at Mission00.loadMission00Finished.
 -- =========================================================
 
-NPCSettingsHubBridge = {}
+NPCSettingsHubBridge = NPCSettingsHubBridge or {}
 
 -- Exactly the settings the mod's own panel exposes (NPCSettingsPanel.SETTING_LABELS),
 -- with the same admin/player split (admin = not in NPCSettingsPanel.LOCAL_ONLY) and the

--- a/src/integrations/NPCStateLedgerBridge.lua
+++ b/src/integrations/NPCStateLedgerBridge.lua
@@ -27,7 +27,7 @@
 -- happens later, in the first-frame init), rather than letting hook order decide.
 -- =========================================================
 
-NPCStateLedgerBridge = {}
+NPCStateLedgerBridge = NPCStateLedgerBridge or {}
 
 -- Locked persistence key inside the master file. Never renamed after first persist (a
 -- later rename orphans saved NPC state). Matches StateLedger's <Mod>_<Thing> convention.

--- a/src/scripts/ContractorModBridge.lua
+++ b/src/scripts/ContractorModBridge.lua
@@ -15,7 +15,7 @@
 --             add the favor/relationship layer, no entity spawn.
 -- ============================================================
 
-ContractorModBridge = {}
+ContractorModBridge = ContractorModBridge or {}
 ContractorModBridge.__index = ContractorModBridge
 
 local LOG_PREFIX = "[NPC Favor][ContractorBridge]"

--- a/src/scripts/NPCAI.lua
+++ b/src/scripts/NPCAI.lua
@@ -73,7 +73,7 @@
 -- Movement recovery: x += sin(yaw) * speed, z += cos(yaw) * speed.
 -- =========================================================
 
-NPCAI = {}
+NPCAI = NPCAI or {}
 NPCAI_mt = Class(NPCAI)
 
 --- Create a new NPCAI instance.
@@ -3569,7 +3569,7 @@ end
 -- (removes waypoints with < 30° direction change).
 -- =========================================================
 
-NPCPathfinder = {}
+NPCPathfinder = NPCPathfinder or {}
 NPCPathfinder_mt = Class(NPCPathfinder)
 
 --- Create a new NPCPathfinder.

--- a/src/scripts/NPCEntity.lua
+++ b/src/scripts/NPCEntity.lua
@@ -88,7 +88,7 @@
 --            → removeNPCEntity() on despawn → cleanupStaleEntities() periodically
 -- =========================================================
 
-NPCEntity = {}
+NPCEntity = NPCEntity or {}
 NPCEntity_mt = Class(NPCEntity)
 
 -- Y offset to align model feet with terrain surface.

--- a/src/scripts/NPCFavorHUD.lua
+++ b/src/scripts/NPCFavorHUD.lua
@@ -38,11 +38,11 @@ function NPCFavorHUD.new(npcSystem)
     -- Middle-Left-Top in the suite's non-overlap layout. Saved drag XML wins.
     -- Wizard 2026-08-21: factory home is the suite layout Wizard arranged
     -- in-game (left column). Saved settings still win on load.
-    self.posX = 0.023125
-    self.posY = 0.714444
+    self.posX = 0.024167
+    self.posY = 0.712592
 
     -- Scale multiplier applied to all dimensions and text
-    self.scale = 1.178089   -- factory suite layout (Wizard 2026-08-21)
+    self.scale = 1.200786   -- factory suite layout (Wizard 2026-08-22)
 
     -- Edit/drag state (runtime only, never persisted)
     self.editMode = false
@@ -62,7 +62,7 @@ function NPCFavorHUD.new(npcSystem)
     self.MAX_SCALE = 2.0
 
     -- Width multiplier (adjusted by edge-drag, independent of scale)
-    self.widthMult = 1.0
+    self.widthMult = 0.517187   -- factory suite layout (Wizard 2026-08-22)
     self.MIN_WIDTH_MULT = 0.5
     self.MAX_WIDTH_MULT = 2.0
     self.edgeDragging = nil  -- nil, "left", or "right"
@@ -138,10 +138,10 @@ end
 
 function NPCFavorHUD:loadFromSettings(settings)
     if not settings then return end
-    self.posX = settings.favorHudPosX or 0.023125
-    self.posY = settings.favorHudPosY or 0.714444
-    self.scale = settings.favorHudScale or 1.178089
-    self.widthMult = settings.favorHudWidthMult or 1.0
+    self.posX = settings.favorHudPosX or 0.024167
+    self.posY = settings.favorHudPosY or 0.712592
+    self.scale = settings.favorHudScale or 1.200786
+    self.widthMult = settings.favorHudWidthMult or 0.517187
     self:clampPosition()
 end
 
@@ -185,6 +185,14 @@ function NPCFavorHUD:enterEditMode()
 end
 
 function NPCFavorHUD:exitEditMode()
+    -- 2026-08-22 (Wizard): while MasterHUD suite edit is ON, the suite owns this
+    -- session - only the suite exit (bridge sets _suiteExiting) may end it. The
+    -- in-vehicle auto-exit in main.lua used to kill the favor HUD's edit one frame
+    -- after the suite entered it (log 18:45:07.588 enabled -> .599 disabled).
+    local mh = (g_currentMission ~= nil and g_currentMission.masterHUD) or g_masterHUD
+    if mh ~= nil and mh.isLayoutEditMode ~= nil and mh:isLayoutEditMode() and not self._suiteExiting then
+        return
+    end
     self.editMode = false
     self.dragging = false
     self.resizing = false

--- a/src/scripts/NPCFavorSystem.lua
+++ b/src/scripts/NPCFavorSystem.lua
@@ -33,7 +33,7 @@
 -- Manages favor requests, tracking, and completion
 -- =========================================================
 
-NPCFavorSystem = {}
+NPCFavorSystem = NPCFavorSystem or {}
 NPCFavorSystem_mt = Class(NPCFavorSystem)
 
 -- Per-personality category weight multipliers for favor type selection.

--- a/src/scripts/NPCFieldWork.lua
+++ b/src/scripts/NPCFieldWork.lua
@@ -11,7 +11,7 @@
 -- endpoints (~3m apart) for clean, realistic movement.
 -- =========================================================
 
-NPCFieldWork = {}
+NPCFieldWork = NPCFieldWork or {}
 local NPCFieldWork_mt = {__index = NPCFieldWork}
 
 --- Constructor

--- a/src/scripts/NPCInteractionUI.lua
+++ b/src/scripts/NPCInteractionUI.lua
@@ -52,11 +52,11 @@
 -- FS25 project() API: project(worldX, worldY, worldZ) → screenX, screenY, screenZ (0-1 normalized)
 -- =========================================================
 
-NPCInteractionUI = {}
+NPCInteractionUI = NPCInteractionUI or {}
 NPCInteractionUI_mt = Class(NPCInteractionUI)
 
 -- Mod-scoped i18n with Missing-reject (same class as MDMUtil.getModText / NPCDialog).
-local NPC_UI_MOD_NAME = g_currentModName
+local NPC_UI_MOD_NAME = (NPCFavorModName or g_currentModName)
 local function getModText(key, fallback)
     if key == nil or key == "" then
         return fallback

--- a/src/scripts/NPCRelationshipManager.lua
+++ b/src/scripts/NPCRelationshipManager.lua
@@ -31,7 +31,7 @@
 -- Manages relationships between player and NPCs
 -- =========================================================
 
-NPCRelationshipManager = {}
+NPCRelationshipManager = NPCRelationshipManager or {}
 NPCRelationshipManager_mt = Class(NPCRelationshipManager)
 
 function NPCRelationshipManager.new(npcSystem)

--- a/src/scripts/NPCScheduler.lua
+++ b/src/scripts/NPCScheduler.lua
@@ -70,7 +70,7 @@
 --   Overnight ranges (start > end, e.g., 22→6) are handled correctly.
 -- =========================================================
 
-NPCScheduler = {}
+NPCScheduler = NPCScheduler or {}
 NPCScheduler_mt = Class(NPCScheduler)
 
 --- Create a new NPCScheduler.
@@ -1122,7 +1122,7 @@ function NPCScheduler:getScheduleSummary(npc)
     local title = "My plans today:"
     local nowMarker = " ← NOW"
     -- Prefer modEnv; reject Giants Missing banners (truthy on miss).
-    local modEnv = g_modEnvironments and g_modEnvironments[g_currentModName]
+    local modEnv = g_modEnvironments and g_modEnvironments[(NPCFavorModName or g_currentModName)]
     local i18n = (modEnv and modEnv.i18n) or g_i18n
     if i18n ~= nil then
         local okT, t = pcall(function() return i18n:getText("npc_schedule_title") end)

--- a/src/scripts/NPCTeleport.lua
+++ b/src/scripts/NPCTeleport.lua
@@ -13,7 +13,7 @@
 --   - Favor Management dialog "Goto" buttons (NPCFavorManagementDialog.lua)
 -- =========================================================
 
-NPCTeleport = {}
+NPCTeleport = NPCTeleport or {}
 
 --- Compute a safe approach position near an NPC: in front of them if standing,
 -- behind them (facing the same way) if moving, snapped to terrain, and nudged

--- a/src/scripts/NPCTreatment.lua
+++ b/src/scripts/NPCTreatment.lua
@@ -32,7 +32,7 @@
 -- Author: TisonK
 -- =========================================================
 
-NPCTreatment = {}
+NPCTreatment = NPCTreatment or {}
 
 NPCTreatment.ENABLED = true
 

--- a/src/settings/NPCConfig.lua
+++ b/src/settings/NPCConfig.lua
@@ -26,7 +26,7 @@
 -- Contains NPC definitions, names, and configuration data
 -- =========================================================
 
-NPCConfig = {}
+NPCConfig = NPCConfig or {}
 local NPCConfig_mt = Class(NPCConfig)
 
 function NPCConfig.new()

--- a/src/settings/NPCFavorGUI.lua
+++ b/src/settings/NPCFavorGUI.lua
@@ -28,7 +28,7 @@
 -- Handles console commands and GUI integration
 -- =========================================================
 
-NPCFavorGUI = {}
+NPCFavorGUI = NPCFavorGUI or {}
 NPCFavorGUI_mt = Class(NPCFavorGUI)
 
 function NPCFavorGUI.new(npcSystem)

--- a/src/settings/NPCSettings.lua
+++ b/src/settings/NPCSettings.lua
@@ -30,7 +30,7 @@
 local SETTINGS_SCHEMA_VERSION = "1.2.4"
 
 ---@class NPCSettings
-NPCSettings = {}
+NPCSettings = NPCSettings or {}
 local NPCSettings_mt = Class(NPCSettings)
 
 function NPCSettings.new()

--- a/src/settings/NPCSettingsIntegration.lua
+++ b/src/settings/NPCSettingsIntegration.lua
@@ -2,12 +2,12 @@
 -- FS25 NPC Favor Mod - Settings Integration
 -- =========================================================
 -- ESC menu injection removed in v1.2.5.0.
--- Settings are now managed by NPCSettingsPanel (F5).
+-- Settings are now managed by NPCSettingsPanel (NPC_SETTINGS action, player-assigned key).
 -- This file is kept as a subsystem stub — NPCSystem holds
 -- a reference to the instance and calls lifecycle methods.
 -- =========================================================
 
-NPCSettingsIntegration = {}
+NPCSettingsIntegration = NPCSettingsIntegration or {}
 NPCSettingsIntegration_mt = Class(NPCSettingsIntegration)
 
 function NPCSettingsIntegration.new(npcSystem)

--- a/src/settings/NPCSettingsPanel.lua
+++ b/src/settings/NPCSettingsPanel.lua
@@ -2,15 +2,15 @@
 -- FS25 NPC Favor — Settings Panel
 -- =========================================================
 -- Fully custom-drawn settings panel. No XML — pure overlay.
--- Open/close: F5
+-- Open/close: NPC_SETTINGS action (player-assigned key)
 -- Landing page → category card → settings list.
 -- =========================================================
 
 ---@class NPCSettingsPanel
-NPCSettingsPanel = {}
+NPCSettingsPanel = NPCSettingsPanel or {}
 local NPCSettingsPanel_mt = Class(NPCSettingsPanel)
 
-local NPC_MOD_NAME = g_currentModName
+local NPC_MOD_NAME = (NPCFavorModName or g_currentModName)
 
 -- ── i18n helper ───────────────────────────────────────────
 local function tr(key, fallback)
@@ -581,7 +581,7 @@ function NPCSettingsPanel:drawInfoBar()
         self:registerClick("back", bbX, bbY, bbW, bbH)
     else
         self:drawText(PX + PW - PAD, textY, TS_SMALL,
-            tr("npc_panel_btn_close_hint", "F5 to close"), C.hint, RenderText.ALIGN_RIGHT, false)
+            tr("npc_panel_btn_close_hint", "Settings key to close"), C.hint, RenderText.ALIGN_RIGHT, false)
     end
 end
 

--- a/src/utils/TimeHelper.lua
+++ b/src/utils/TimeHelper.lua
@@ -36,7 +36,7 @@
 -- Time conversion and formatting utilities
 -- =========================================================
 
-TimeHelper = {}
+TimeHelper = TimeHelper or {}
 
 -- Convert milliseconds to hours, minutes, seconds
 function TimeHelper.msToHMS(ms)

--- a/src/utils/VectorHelper.lua
+++ b/src/utils/VectorHelper.lua
@@ -31,7 +31,7 @@
 -- Math utilities for vector operations
 -- =========================================================
 
-VectorHelper = {}
+VectorHelper = VectorHelper or {}
 
 function VectorHelper.distance2D(x1, z1, x2, z2)
     local dx = x2 - x1

--- a/translations/lang_br.xml
+++ b/translations/lang_br.xml
@@ -153,7 +153,7 @@
 		<text name="npc_hud_locked_long" text="Quando bloqueado, a lista de favores não pode ser movida ou redimensionada" />
 		<text name="npc_hud_scale_short" text="Tamanho do HUD" />
 		<text name="npc_panel_scale_short" text="[EN] Settings Panel Scale"/>
-		<text name="npc_panel_scale_long" text="[EN] Size of the F5 settings panel (independent of the favor HUD)"/>
+		<text name="npc_panel_scale_long" text="[EN] Size of the NPC Settings settings panel (independent of the favor HUD)"/>
 		<text name="npc_hud_scale_long" text="Tamanho da lista de favores ativos na tela" />
 		<text name="npc_admin_title" text="Painel Admin NPC" />
 		<text name="npc_admin_subtitle_fmt" text="%d NPCs ativos  |  Clique Editar para ajustar" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_ct.xml
+++ b/translations/lang_ct.xml
@@ -160,7 +160,7 @@
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />
 		<text name="npc_hud_scale_short" text="Favor HUD Scale" />
 		<text name="npc_panel_scale_short" text="Settings Panel Scale" />
-		<text name="npc_panel_scale_long" text="Size of the F5 settings panel (independent of the favor HUD)" />
+		<text name="npc_panel_scale_long" text="Size of the NPC Settings settings panel (independent of the favor HUD)" />
 		<text name="npc_hud_scale_long" text="Size of the active favors list on screen" />
 		<text name="npc_admin_title" text="NPC Admin Panel" />
 		<text name="npc_admin_subtitle_fmt" text="%d active NPCs  |  Click Edit to adjust relationship" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_cz.xml
+++ b/translations/lang_cz.xml
@@ -153,7 +153,7 @@
 		<text name="npc_hud_locked_long" text="Když je zamknutý, seznam laskavostí nelze přesunout ani změnit velikost" />
 		<text name="npc_hud_scale_short" text="Velikost HUD laskavostí" />
 		<text name="npc_panel_scale_short" text="[EN] Settings Panel Scale"/>
-		<text name="npc_panel_scale_long" text="[EN] Size of the F5 settings panel (independent of the favor HUD)"/>
+		<text name="npc_panel_scale_long" text="[EN] Size of the NPC Settings settings panel (independent of the favor HUD)"/>
 		<text name="npc_hud_scale_long" text="Velikost seznamu aktivních laskavostí na obrazovce" />
 		<text name="npc_admin_title" text="Admin panel NPC" />
 		<text name="npc_admin_subtitle_fmt" text="%d aktivních NPC  |  Klikněte Upravit pro úpravu" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_da.xml
+++ b/translations/lang_da.xml
@@ -160,7 +160,7 @@
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />
 		<text name="npc_hud_scale_short" text="Favor HUD Scale" />
 		<text name="npc_panel_scale_short" text="Settings Panel Scale" />
-		<text name="npc_panel_scale_long" text="Size of the F5 settings panel (independent of the favor HUD)" />
+		<text name="npc_panel_scale_long" text="Size of the NPC Settings settings panel (independent of the favor HUD)" />
 		<text name="npc_hud_scale_long" text="Size of the active favors list on screen" />
 		<text name="npc_admin_title" text="NPC Admin Panel" />
 		<text name="npc_admin_subtitle_fmt" text="%d active NPCs  |  Click Edit to adjust relationship" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_de.xml
+++ b/translations/lang_de.xml
@@ -153,7 +153,7 @@
 		<text name="npc_hud_locked_long" text="Wenn gesperrt, kann die Gefallenliste nicht verschoben oder skaliert werden" />
 		<text name="npc_hud_scale_short" text="Gefallen-HUD Größe" />
 		<text name="npc_panel_scale_short" text="Einstellungen-Fenstergröße"/>
-		<text name="npc_panel_scale_long" text="Größe des F5-Einstellungsfensters (unabhängig vom Favor-HUD)"/>
+		<text name="npc_panel_scale_long" text="Größe des NPC-Einstellungen-Einstellungsfensters (unabhängig vom Favor-HUD)"/>
 		<text name="npc_hud_scale_long" text="Größe der aktiven Gefallenliste auf dem Bildschirm" />
 		<text name="npc_admin_title" text="NPC Admin-Panel" />
 		<text name="npc_admin_subtitle_fmt" text="%d aktive NPCs  |  Bearbeiten klicken zum Anpassen" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin-Aktionen" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Zurück" />
-		<text name="npc_panel_btn_close_hint"       text="F5 zum Schließen" />
+		<text name="npc_panel_btn_close_hint"       text="NPC-Einstellungen zum Schließen" />
 		<text name="npc_panel_btn_open"             text="Öffnen" />
 		<text name="npc_panel_btn_configure"        text="Konfigurieren" />
 		<text name="npc_panel_btn_reset"            text="Kategorie zurücksetzen" />

--- a/translations/lang_ea.xml
+++ b/translations/lang_ea.xml
@@ -160,7 +160,7 @@
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />
 		<text name="npc_hud_scale_short" text="Favor HUD Scale" />
 		<text name="npc_panel_scale_short" text="Settings Panel Scale" />
-		<text name="npc_panel_scale_long" text="Size of the F5 settings panel (independent of the favor HUD)" />
+		<text name="npc_panel_scale_long" text="Size of the NPC Settings settings panel (independent of the favor HUD)" />
 		<text name="npc_hud_scale_long" text="Size of the active favors list on screen" />
 		<text name="npc_admin_title" text="NPC Admin Panel" />
 		<text name="npc_admin_subtitle_fmt" text="%d active NPCs  |  Click Edit to adjust relationship" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_en.xml
+++ b/translations/lang_en.xml
@@ -160,7 +160,7 @@
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />
 		<text name="npc_hud_scale_short" text="Favor HUD Scale" />
 		<text name="npc_panel_scale_short" text="Settings Panel Scale" />
-		<text name="npc_panel_scale_long" text="Size of the F5 settings panel (independent of the favor HUD)" />
+		<text name="npc_panel_scale_long" text="Size of the NPC Settings settings panel (independent of the favor HUD)" />
 		<text name="npc_hud_scale_long" text="Size of the active favors list on screen" />
 		<text name="npc_admin_title" text="NPC Admin Panel" />
 		<text name="npc_admin_subtitle_fmt" text="%d active NPCs  |  Click Edit to adjust relationship" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_es.xml
+++ b/translations/lang_es.xml
@@ -153,7 +153,7 @@
 		<text name="npc_hud_locked_long" text="Cuando está bloqueado, la lista de favores no se puede mover ni redimensionar" />
 		<text name="npc_hud_scale_short" text="Tamaño del HUD" />
 		<text name="npc_panel_scale_short" text="[EN] Settings Panel Scale"/>
-		<text name="npc_panel_scale_long" text="[EN] Size of the F5 settings panel (independent of the favor HUD)"/>
+		<text name="npc_panel_scale_long" text="[EN] Size of the NPC Settings settings panel (independent of the favor HUD)"/>
 		<text name="npc_hud_scale_long" text="Tamaño de la lista de favores activos en pantalla" />
 		<text name="npc_admin_title" text="Panel Admin NPC" />
 		<text name="npc_admin_subtitle_fmt" text="%d NPCs activos  |  Haz clic en Editar para ajustar" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_fc.xml
+++ b/translations/lang_fc.xml
@@ -160,7 +160,7 @@
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />
 		<text name="npc_hud_scale_short" text="Favor HUD Scale" />
 		<text name="npc_panel_scale_short" text="Settings Panel Scale" />
-		<text name="npc_panel_scale_long" text="Size of the F5 settings panel (independent of the favor HUD)" />
+		<text name="npc_panel_scale_long" text="Size of the NPC Settings settings panel (independent of the favor HUD)" />
 		<text name="npc_hud_scale_long" text="Size of the active favors list on screen" />
 		<text name="npc_admin_title" text="NPC Admin Panel" />
 		<text name="npc_admin_subtitle_fmt" text="%d active NPCs  |  Click Edit to adjust relationship" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_fi.xml
+++ b/translations/lang_fi.xml
@@ -160,7 +160,7 @@
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />
 		<text name="npc_hud_scale_short" text="Favor HUD Scale" />
 		<text name="npc_panel_scale_short" text="Settings Panel Scale" />
-		<text name="npc_panel_scale_long" text="Size of the F5 settings panel (independent of the favor HUD)" />
+		<text name="npc_panel_scale_long" text="Size of the NPC Settings settings panel (independent of the favor HUD)" />
 		<text name="npc_hud_scale_long" text="Size of the active favors list on screen" />
 		<text name="npc_admin_title" text="NPC Admin Panel" />
 		<text name="npc_admin_subtitle_fmt" text="%d active NPCs  |  Click Edit to adjust relationship" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_fr.xml
+++ b/translations/lang_fr.xml
@@ -153,7 +153,7 @@
 		<text name="npc_hud_locked_long" text="Quand verrouillé, la liste des faveurs ne peut pas être déplacée ou redimensionnée" />
 		<text name="npc_hud_scale_short" text="Taille du HUD" />
 		<text name="npc_panel_scale_short" text="[EN] Settings Panel Scale"/>
-		<text name="npc_panel_scale_long" text="[EN] Size of the F5 settings panel (independent of the favor HUD)"/>
+		<text name="npc_panel_scale_long" text="[EN] Size of the NPC Settings settings panel (independent of the favor HUD)"/>
 		<text name="npc_hud_scale_long" text="Taille de la liste des faveurs actives à l'écran" />
 		<text name="npc_admin_title" text="Panneau Admin PNJ" />
 		<text name="npc_admin_subtitle_fmt" text="%d PNJ actifs  |  Cliquez Modifier pour ajuster" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_hu.xml
+++ b/translations/lang_hu.xml
@@ -160,7 +160,7 @@
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />
 		<text name="npc_hud_scale_short" text="Favor HUD Scale" />
 		<text name="npc_panel_scale_short" text="Settings Panel Scale" />
-		<text name="npc_panel_scale_long" text="Size of the F5 settings panel (independent of the favor HUD)" />
+		<text name="npc_panel_scale_long" text="Size of the NPC Settings settings panel (independent of the favor HUD)" />
 		<text name="npc_hud_scale_long" text="Size of the active favors list on screen" />
 		<text name="npc_admin_title" text="NPC Admin Panel" />
 		<text name="npc_admin_subtitle_fmt" text="%d active NPCs  |  Click Edit to adjust relationship" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_id.xml
+++ b/translations/lang_id.xml
@@ -160,7 +160,7 @@
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />
 		<text name="npc_hud_scale_short" text="Favor HUD Scale" />
 		<text name="npc_panel_scale_short" text="Settings Panel Scale" />
-		<text name="npc_panel_scale_long" text="Size of the F5 settings panel (independent of the favor HUD)" />
+		<text name="npc_panel_scale_long" text="Size of the NPC Settings settings panel (independent of the favor HUD)" />
 		<text name="npc_hud_scale_long" text="Size of the active favors list on screen" />
 		<text name="npc_admin_title" text="NPC Admin Panel" />
 		<text name="npc_admin_subtitle_fmt" text="%d active NPCs  |  Click Edit to adjust relationship" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_it.xml
+++ b/translations/lang_it.xml
@@ -153,7 +153,7 @@
 		<text name="npc_hud_locked_long" text="Quando bloccato, la lista favori non può essere spostata o ridimensionata" />
 		<text name="npc_hud_scale_short" text="Dimensione HUD favori" />
 		<text name="npc_panel_scale_short" text="[EN] Settings Panel Scale"/>
-		<text name="npc_panel_scale_long" text="[EN] Size of the F5 settings panel (independent of the favor HUD)"/>
+		<text name="npc_panel_scale_long" text="[EN] Size of the NPC Settings settings panel (independent of the favor HUD)"/>
 		<text name="npc_hud_scale_long" text="Dimensione della lista favori attivi sullo schermo" />
 		<text name="npc_admin_title" text="Pannello Admin NPC" />
 		<text name="npc_admin_subtitle_fmt" text="%d NPC attivi  |  Clicca Modifica per regolare" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_jp.xml
+++ b/translations/lang_jp.xml
@@ -160,7 +160,7 @@
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />
 		<text name="npc_hud_scale_short" text="Favor HUD Scale" />
 		<text name="npc_panel_scale_short" text="Settings Panel Scale" />
-		<text name="npc_panel_scale_long" text="Size of the F5 settings panel (independent of the favor HUD)" />
+		<text name="npc_panel_scale_long" text="Size of the NPC Settings settings panel (independent of the favor HUD)" />
 		<text name="npc_hud_scale_long" text="Size of the active favors list on screen" />
 		<text name="npc_admin_title" text="NPC Admin Panel" />
 		<text name="npc_admin_subtitle_fmt" text="%d active NPCs  |  Click Edit to adjust relationship" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_kr.xml
+++ b/translations/lang_kr.xml
@@ -160,7 +160,7 @@
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />
 		<text name="npc_hud_scale_short" text="Favor HUD Scale" />
 		<text name="npc_panel_scale_short" text="Settings Panel Scale" />
-		<text name="npc_panel_scale_long" text="Size of the F5 settings panel (independent of the favor HUD)" />
+		<text name="npc_panel_scale_long" text="Size of the NPC Settings settings panel (independent of the favor HUD)" />
 		<text name="npc_hud_scale_long" text="Size of the active favors list on screen" />
 		<text name="npc_admin_title" text="NPC Admin Panel" />
 		<text name="npc_admin_subtitle_fmt" text="%d active NPCs  |  Click Edit to adjust relationship" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_nl.xml
+++ b/translations/lang_nl.xml
@@ -160,7 +160,7 @@
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />
 		<text name="npc_hud_scale_short" text="Favor HUD Scale" />
 		<text name="npc_panel_scale_short" text="Settings Panel Scale" />
-		<text name="npc_panel_scale_long" text="Size of the F5 settings panel (independent of the favor HUD)" />
+		<text name="npc_panel_scale_long" text="Size of the NPC Settings settings panel (independent of the favor HUD)" />
 		<text name="npc_hud_scale_long" text="Size of the active favors list on screen" />
 		<text name="npc_admin_title" text="NPC Admin Panel" />
 		<text name="npc_admin_subtitle_fmt" text="%d active NPCs  |  Click Edit to adjust relationship" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_no.xml
+++ b/translations/lang_no.xml
@@ -160,7 +160,7 @@
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />
 		<text name="npc_hud_scale_short" text="Favor HUD Scale" />
 		<text name="npc_panel_scale_short" text="Settings Panel Scale" />
-		<text name="npc_panel_scale_long" text="Size of the F5 settings panel (independent of the favor HUD)" />
+		<text name="npc_panel_scale_long" text="Size of the NPC Settings settings panel (independent of the favor HUD)" />
 		<text name="npc_hud_scale_long" text="Size of the active favors list on screen" />
 		<text name="npc_admin_title" text="NPC Admin Panel" />
 		<text name="npc_admin_subtitle_fmt" text="%d active NPCs  |  Click Edit to adjust relationship" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_pl.xml
+++ b/translations/lang_pl.xml
@@ -153,7 +153,7 @@
 		<text name="npc_hud_locked_long" text="Gdy zablokowany, lista przysług nie może być przesuwana ani skalowana" />
 		<text name="npc_hud_scale_short" text="Rozmiar HUD przysług" />
 		<text name="npc_panel_scale_short" text="[EN] Settings Panel Scale"/>
-		<text name="npc_panel_scale_long" text="[EN] Size of the F5 settings panel (independent of the favor HUD)"/>
+		<text name="npc_panel_scale_long" text="[EN] Size of the NPC Settings settings panel (independent of the favor HUD)"/>
 		<text name="npc_hud_scale_long" text="Rozmiar listy aktywnych przysług na ekranie" />
 		<text name="npc_admin_title" text="Panel admina NPC" />
 		<text name="npc_admin_subtitle_fmt" text="%d aktywnych NPC  |  Kliknij Edytuj, aby dostosować" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_pt.xml
+++ b/translations/lang_pt.xml
@@ -160,7 +160,7 @@
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />
 		<text name="npc_hud_scale_short" text="Favor HUD Scale" />
 		<text name="npc_panel_scale_short" text="Settings Panel Scale" />
-		<text name="npc_panel_scale_long" text="Size of the F5 settings panel (independent of the favor HUD)" />
+		<text name="npc_panel_scale_long" text="Size of the NPC Settings settings panel (independent of the favor HUD)" />
 		<text name="npc_hud_scale_long" text="Size of the active favors list on screen" />
 		<text name="npc_admin_title" text="NPC Admin Panel" />
 		<text name="npc_admin_subtitle_fmt" text="%d active NPCs  |  Click Edit to adjust relationship" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_ro.xml
+++ b/translations/lang_ro.xml
@@ -160,7 +160,7 @@
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />
 		<text name="npc_hud_scale_short" text="Favor HUD Scale" />
 		<text name="npc_panel_scale_short" text="Settings Panel Scale" />
-		<text name="npc_panel_scale_long" text="Size of the F5 settings panel (independent of the favor HUD)" />
+		<text name="npc_panel_scale_long" text="Size of the NPC Settings settings panel (independent of the favor HUD)" />
 		<text name="npc_hud_scale_long" text="Size of the active favors list on screen" />
 		<text name="npc_admin_title" text="NPC Admin Panel" />
 		<text name="npc_admin_subtitle_fmt" text="%d active NPCs  |  Click Edit to adjust relationship" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_ru.xml
+++ b/translations/lang_ru.xml
@@ -153,7 +153,7 @@
 		<text name="npc_hud_locked_long" text="Когда заблокировано, список услуг нельзя перемещать или масштабировать" />
 		<text name="npc_hud_scale_short" text="Размер HUD услуг" />
 		<text name="npc_panel_scale_short" text="[EN] Settings Panel Scale"/>
-		<text name="npc_panel_scale_long" text="[EN] Size of the F5 settings panel (independent of the favor HUD)"/>
+		<text name="npc_panel_scale_long" text="[EN] Size of the NPC Settings settings panel (independent of the favor HUD)"/>
 		<text name="npc_hud_scale_long" text="Размер списка активных услуг на экране" />
 		<text name="npc_admin_title" text="Админ-панель NPC" />
 		<text name="npc_admin_subtitle_fmt" text="%d активных NPC  |  Нажмите Редактировать для настройки" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_sv.xml
+++ b/translations/lang_sv.xml
@@ -160,7 +160,7 @@
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />
 		<text name="npc_hud_scale_short" text="Favor HUD Scale" />
 		<text name="npc_panel_scale_short" text="Settings Panel Scale" />
-		<text name="npc_panel_scale_long" text="Size of the F5 settings panel (independent of the favor HUD)" />
+		<text name="npc_panel_scale_long" text="Size of the NPC Settings settings panel (independent of the favor HUD)" />
 		<text name="npc_hud_scale_long" text="Size of the active favors list on screen" />
 		<text name="npc_admin_title" text="NPC Admin Panel" />
 		<text name="npc_admin_subtitle_fmt" text="%d active NPCs  |  Click Edit to adjust relationship" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_tr.xml
+++ b/translations/lang_tr.xml
@@ -160,7 +160,7 @@
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />
 		<text name="npc_hud_scale_short" text="Favor HUD Scale" />
 		<text name="npc_panel_scale_short" text="Settings Panel Scale" />
-		<text name="npc_panel_scale_long" text="Size of the F5 settings panel (independent of the favor HUD)" />
+		<text name="npc_panel_scale_long" text="Size of the NPC Settings settings panel (independent of the favor HUD)" />
 		<text name="npc_hud_scale_long" text="Size of the active favors list on screen" />
 		<text name="npc_admin_title" text="NPC Admin Panel" />
 		<text name="npc_admin_subtitle_fmt" text="%d active NPCs  |  Click Edit to adjust relationship" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_uk.xml
+++ b/translations/lang_uk.xml
@@ -153,7 +153,7 @@
 		<text name="npc_hud_locked_long" text="Коли заблоковано, список послуг не можна переміщувати або масштабувати" />
 		<text name="npc_hud_scale_short" text="Розмір HUD послуг" />
 		<text name="npc_panel_scale_short" text="[EN] Settings Panel Scale"/>
-		<text name="npc_panel_scale_long" text="[EN] Size of the F5 settings panel (independent of the favor HUD)"/>
+		<text name="npc_panel_scale_long" text="[EN] Size of the NPC Settings settings panel (independent of the favor HUD)"/>
 		<text name="npc_hud_scale_long" text="Розмір списку активних послуг на екрані" />
 		<text name="npc_admin_title" text="Адмін-панель NPC" />
 		<text name="npc_admin_subtitle_fmt" text="%d активних NPC  |  Натисніть Редагувати для налаштування" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/translations/lang_vi.xml
+++ b/translations/lang_vi.xml
@@ -160,7 +160,7 @@
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />
 		<text name="npc_hud_scale_short" text="Favor HUD Scale" />
 		<text name="npc_panel_scale_short" text="Settings Panel Scale" />
-		<text name="npc_panel_scale_long" text="Size of the F5 settings panel (independent of the favor HUD)" />
+		<text name="npc_panel_scale_long" text="Size of the NPC Settings settings panel (independent of the favor HUD)" />
 		<text name="npc_hud_scale_long" text="Size of the active favors list on screen" />
 		<text name="npc_admin_title" text="NPC Admin Panel" />
 		<text name="npc_admin_subtitle_fmt" text="%d active NPCs  |  Click Edit to adjust relationship" />
@@ -209,7 +209,7 @@
 		<text name="npc_panel_hdr_admin_actions"    text="Admin Actions" />
 		<!-- UI strings -->
 		<text name="npc_panel_btn_back"             text="Back" />
-		<text name="npc_panel_btn_close_hint"       text="F5 to close" />
+		<text name="npc_panel_btn_close_hint"       text="NPC Settings to close" />
 		<text name="npc_panel_btn_open"             text="Open" />
 		<text name="npc_panel_btn_configure"        text="Configure" />
 		<text name="npc_panel_btn_reset"            text="Reset Category" />

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -586,9 +586,16 @@
                                  re-enter the layout the way a list rebuild can.
                                  Parked on the rfFwTableTitle band, which every Table-mode guest
                                  already hides, so the pager collides with nothing that paints. -->
-                            <Button profile="buttonActivate" id="rfFwPagePrev" position="880px -8px" size="120px 24px"
+                            <!-- 2026-08-22 FAIL-FIX (live screenshot 17:11): bottom-right placement inside
+                                 the 1140x428 table frame was correct and is kept; the profile was not.
+                                 RF_CsPivotBtn inherits inputAction MENU_ACTIVATE from buttonActivate, so the
+                                 engine painted a SPACE key chip on BOTH buttons and each chip pushed its own
+                                 label out of its 120px box into the neighbour. RF_FwPagerBtn extends
+                                 fs25_wideButton instead - identical chrome, no inputAction, so no chip.
+                                 See rfEscProfiles.xml. Page keys: . / > next, , / < back. -->
+                            <Button profile="RF_FwPagerBtn" id="rfFwPagePrev" position="880px -396px" size="120px 24px"
                                     visible="false" text="" onClick="onClickRfFwPagePrev"/>
-                            <Button profile="buttonActivate" id="rfFwPageNext" position="1010px -8px" size="120px 24px"
+                            <Button profile="RF_FwPagerBtn" id="rfFwPageNext" position="1010px -396px" size="120px 24px"
                                     visible="false" text="" onClick="onClickRfFwPageNext"/>
                             <Text profile="RF_HintText" id="rfFwEmptyHint" position="10px -68px" size="1120px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>

--- a/xml/gui/rfEscProfiles.xml
+++ b/xml/gui/rfEscProfiles.xml
@@ -381,6 +381,29 @@
         <isTriggerableByGlobalAction value="false"/>
         <iconSize value="30px 30px"/>
     </Profile>
+
+    <!-- 2026-08-22 FAIL-FIX (live screenshot 17:11): the row pager must NOT inherit an
+         inputAction. RF_CsPivotBtn extends buttonActivate, and buttonActivate sets
+         inputAction MENU_ACTIVATE (base game guiProfiles.xml:2084-2087). The engine paints
+         that action's SPACE key chip on every button carrying it, which is what shoved each
+         label out of its own 120px box and into the next button ("< BACK" + the neighbouring
+         chip is what read as "BACKSPACE" on screen). hideKeyboardGlyph did NOT suppress it
+         here - it appears exactly once in the whole base-game profile set, on a disabled
+         gamepad-only selector - and isTriggerableByGlobalAction is not an engine property at
+         all (zero occurrences base game), so both were inert.
+         fs25_wideButton (guiProfiles.xml:2671) is buttonActivate's OWN base minus the
+         inputAction, so this profile is the same chrome with no key chip to draw. The mouse
+         click still works: it runs through onClick, which never needed the input action.
+         Page keys live in RfPdaMenuPage:keyEvent as . / > and , / < . -->
+    <Profile name="RF_FwPagerBtn" extends="fs25_wideButton" with="anchorTopLeft pivotTopLeft">
+        <size value="120px 24px"/>
+        <textSize value="13px"/>
+        <textBold value="true"/>
+        <textUpperCase value="false"/>
+        <fitToContent value="false"/>
+        <textAutoWidth value="false"/>
+        <textAlignment value="center"/>
+    </Profile>
     <Profile name="RF_ProductsRowsClip" extends="emptyPanel" with="anchorTopLeft pivotTopLeft">
         <size value="560px 160px"/>
         <clipChildren value="true"/>


### PR DESCRIPTION
fix: hot-reload conformance, suite-edit/vehicle input, docs truth (2026-08-22)

- entry/module latch: g_currentModDirectory/Name latched into module globals with g_modsDirectory fallback so live re-source cannot nil-crash
- hot-reload conformance: class tables declared X = X or {} so Ctrl+R reloads update live instances; raw g_currentModDirectory readers fall back to the latch
- docs: key bindings / HUD behaviour brought in line with the actual modDesc bindings (no phantom default keys)
- l10n/store text: stale key claims replaced with the real bind or the localized action name
- RF PDA pager: glyph-free RF_CsPivotBtn buttons anchored bottom-right of the table frame; page keys . / > next and , / < back
- favor HUD joins suite layout edit in vehicles: in-vehicle auto-exit rule removed; exitEditMode defers to MasterHUD while suite edit is on; bridge reload-safe with ungated delivery

Built zips are not part of this change. UTF-8 without BOM on all touched files.