### PR TITLE
feat: playtest NPC Favor Esc PDA guest, HUD, and l10n sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to the FS25_NPCFavor mod are documented below, organized by 
 
 ---
 
+## Unreleased
+
+### Added
+- **Control Center actions** (suite Control Center, requires SettingsHub): `FAVOR_MENU`, `NPC_LIST`, `NPC_SETTINGS`.
+- **Playtest fixes:** NpcRfPdaGuest (Esc neighbor-table pager), NPCFavorHUD, NPC_HUD_EDIT (RShift+Z), translation sync.
+
+---
+
 ## v1.2.7.1 -- Favor completion fix, money authority, core-service bridges, and a companion read API
 
 ### Favors

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -44,14 +44,16 @@
         <action name="NPC_INTERACT" />
         <action name="FAVOR_MENU" />
         <action name="NPC_LIST" />
-        <action name="HUD_EDIT_MODE" />
         <action name="NPC_SETTINGS" />
+        <action name="NPC_HUD_EDIT" category="ONFOOT VEHICLE" />
     </actions>
     <inputBinding>
         <actionBinding action="NPC_INTERACT" />
         <actionBinding action="FAVOR_MENU" />
         <actionBinding action="NPC_LIST" />
-        <actionBinding action="HUD_EDIT_MODE" />
         <actionBinding action="NPC_SETTINGS" />
+        <actionBinding action="NPC_HUD_EDIT">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_z" />
+        </actionBinding>
     </inputBinding>
 </modDesc>

--- a/src/scripts/NPCEntity.lua
+++ b/src/scripts/NPCEntity.lua
@@ -1425,6 +1425,10 @@ end
 -- @param npc  NPC data table
 -- @param dt   Delta time in seconds
 function NPCEntity:updateNPCEntity(npc, dt)
+    -- Procedural animation offsets. Function-scoped because BOTH the static-model
+    -- path and the debug-node fallback below read them; the static path assigns
+    -- real values, every other path leaves them at 0.
+    local yOffset, yawOffset = 0, 0
     local entity = self.npcEntities[npc.id]
     if not entity then return end
 
@@ -1540,10 +1544,14 @@ function NPCEntity:updateNPCEntity(npc, dt)
         -- Procedural animation timer (persistent per entity)
         entity.animTime = (entity.animTime or 0) + dt
 
-        -- Calculate procedural animation offsets
-        local yOffset = 0
+        -- Calculate procedural animation offsets.
+        -- 2026-08-23: yOffset/yawOffset are declared at FUNCTION scope above, not here.
+        -- They were locals of this else-branch, but the debug-node block further down sits
+        -- outside the branch and also reads them, so there they resolved to nil globals and
+        -- "entity.position.y + nil" threw inside a pcall - silently, which is why the debug
+        -- node never tracked the NPC. Assigning (not re-declaring) keeps both readers on the
+        -- same values.
         local scaleY = entity.scale or 1.0
-        local yawOffset = 0
         local aiState = npc.aiState or "idle"
         local t = entity.animTime
 

--- a/src/scripts/NPCFavorHUD.lua
+++ b/src/scripts/NPCFavorHUD.lua
@@ -38,11 +38,11 @@ function NPCFavorHUD.new(npcSystem)
     -- Middle-Left-Top in the suite's non-overlap layout. Saved drag XML wins.
     -- Wizard 2026-08-21: factory home is the suite layout Wizard arranged
     -- in-game (left column). Saved settings still win on load.
-    self.posX = 0.024167
-    self.posY = 0.712592
+    self.posX = 0.598125
+    self.posY = 0.303333
 
     -- Scale multiplier applied to all dimensions and text
-    self.scale = 1.200786   -- factory suite layout (Wizard 2026-08-22)
+    self.scale = 0.962974   -- factory suite layout (Wizard 2026-08-22 21:xx capture)
 
     -- Edit/drag state (runtime only, never persisted)
     self.editMode = false
@@ -138,9 +138,9 @@ end
 
 function NPCFavorHUD:loadFromSettings(settings)
     if not settings then return end
-    self.posX = settings.favorHudPosX or 0.024167
-    self.posY = settings.favorHudPosY or 0.712592
-    self.scale = settings.favorHudScale or 1.200786
+    self.posX = settings.favorHudPosX or 0.598125
+    self.posY = settings.favorHudPosY or 0.303333
+    self.scale = settings.favorHudScale or 0.962974
     self.widthMult = settings.favorHudWidthMult or 0.517187
     self:clampPosition()
 end

--- a/translations/lang_br.xml
+++ b/translations/lang_br.xml
@@ -147,7 +147,8 @@
 		<text name="input_FAVOR_MENU" text="Menu de favores" />
 		<text name="input_NPC_LIST" text="Lista NPC" />
 			<text name="npc_schedule_plans" text="Meus planos:" />
-		<text name="input_HUD_EDIT_MODE" text="Alternar edição do HUD" />
+		<text name="input_NPC_HUD_EDIT" text="Alternar edição do HUD" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Arraste para mover | Cantos para redimensionar" />
 		<text name="npc_hud_locked_short" text="Bloquear HUD de favores" />
 		<text name="npc_hud_locked_long" text="Quando bloqueado, a lista de favores não pode ser movida ou redimensionada" />

--- a/translations/lang_ct.xml
+++ b/translations/lang_ct.xml
@@ -154,7 +154,8 @@
 		<text name="input_FAVOR_MENU" text="Favor Menu" />
 		<text name="input_NPC_LIST" text="NPC List" />
 			<text name="npc_schedule_plans" text="My plans:" />
-		<text name="input_HUD_EDIT_MODE" text="Toggle HUD Edit" />
+		<text name="input_NPC_HUD_EDIT" text="Toggle HUD Edit" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Drag to move | Corners to resize" />
 		<text name="npc_hud_locked_short" text="Lock Favor HUD" />
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />

--- a/translations/lang_cz.xml
+++ b/translations/lang_cz.xml
@@ -147,7 +147,8 @@
 		<text name="input_FAVOR_MENU" text="Menu laskavostí" />
 		<text name="input_NPC_LIST" text="Seznam NPC" />
 			<text name="npc_schedule_plans" text="Moje plány:" />
-		<text name="input_HUD_EDIT_MODE" text="Přepnout úpravy HUD" />
+		<text name="input_NPC_HUD_EDIT" text="Přepnout úpravy HUD" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Přetáhněte pro přesun | Rohy pro změnu velikosti" />
 		<text name="npc_hud_locked_short" text="Zamknout HUD laskavostí" />
 		<text name="npc_hud_locked_long" text="Když je zamknutý, seznam laskavostí nelze přesunout ani změnit velikost" />

--- a/translations/lang_da.xml
+++ b/translations/lang_da.xml
@@ -154,7 +154,8 @@
 		<text name="input_FAVOR_MENU" text="Favor Menu" />
 		<text name="input_NPC_LIST" text="NPC List" />
 			<text name="npc_schedule_plans" text="My plans:" />
-		<text name="input_HUD_EDIT_MODE" text="Toggle HUD Edit" />
+		<text name="input_NPC_HUD_EDIT" text="Toggle HUD Edit" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Drag to move | Corners to resize" />
 		<text name="npc_hud_locked_short" text="Lock Favor HUD" />
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />

--- a/translations/lang_de.xml
+++ b/translations/lang_de.xml
@@ -147,7 +147,8 @@
 		<text name="input_FAVOR_MENU" text="Gefallen-Menü" />
 		<text name="input_NPC_LIST" text="NPC-Liste" />
 		<text name="npc_schedule_plans" text="Meine Pläne:" />
-		<text name="input_HUD_EDIT_MODE" text="HUD-Bearbeitung umschalten" />
+		<text name="input_NPC_HUD_EDIT" text="HUD-Bearbeitung umschalten" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Ziehen zum Verschieben | Ecken zum Skalieren" />
 		<text name="npc_hud_locked_short" text="Gefallen-HUD sperren" />
 		<text name="npc_hud_locked_long" text="Wenn gesperrt, kann die Gefallenliste nicht verschoben oder skaliert werden" />

--- a/translations/lang_ea.xml
+++ b/translations/lang_ea.xml
@@ -154,7 +154,8 @@
 		<text name="input_FAVOR_MENU" text="Favor Menu" />
 		<text name="input_NPC_LIST" text="NPC List" />
 			<text name="npc_schedule_plans" text="My plans:" />
-		<text name="input_HUD_EDIT_MODE" text="Toggle HUD Edit" />
+		<text name="input_NPC_HUD_EDIT" text="Toggle HUD Edit" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Drag to move | Corners to resize" />
 		<text name="npc_hud_locked_short" text="Lock Favor HUD" />
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />

--- a/translations/lang_en.xml
+++ b/translations/lang_en.xml
@@ -154,7 +154,8 @@
 		<text name="input_FAVOR_MENU" text="Favor Menu" />
 		<text name="input_NPC_LIST" text="NPC List" />
 			<text name="npc_schedule_plans" text="My plans:" />
-		<text name="input_HUD_EDIT_MODE" text="Toggle HUD Edit" />
+		<text name="input_NPC_HUD_EDIT" text="Toggle HUD Edit" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Drag to move | Corners to resize" />
 		<text name="npc_hud_locked_short" text="Lock Favor HUD" />
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />

--- a/translations/lang_es.xml
+++ b/translations/lang_es.xml
@@ -147,7 +147,8 @@
 		<text name="input_FAVOR_MENU" text="Menú de favores" />
 		<text name="input_NPC_LIST" text="Lista NPC" />
 			<text name="npc_schedule_plans" text="Mis planes:" />
-		<text name="input_HUD_EDIT_MODE" text="Alternar edición HUD" />
+		<text name="input_NPC_HUD_EDIT" text="Alternar edición HUD" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Arrastra para mover | Esquinas para redimensionar" />
 		<text name="npc_hud_locked_short" text="Bloquear HUD de favores" />
 		<text name="npc_hud_locked_long" text="Cuando está bloqueado, la lista de favores no se puede mover ni redimensionar" />

--- a/translations/lang_fc.xml
+++ b/translations/lang_fc.xml
@@ -154,7 +154,8 @@
 		<text name="input_FAVOR_MENU" text="Favor Menu" />
 		<text name="input_NPC_LIST" text="NPC List" />
 			<text name="npc_schedule_plans" text="My plans:" />
-		<text name="input_HUD_EDIT_MODE" text="Toggle HUD Edit" />
+		<text name="input_NPC_HUD_EDIT" text="Toggle HUD Edit" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Drag to move | Corners to resize" />
 		<text name="npc_hud_locked_short" text="Lock Favor HUD" />
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />

--- a/translations/lang_fi.xml
+++ b/translations/lang_fi.xml
@@ -154,7 +154,8 @@
 		<text name="input_FAVOR_MENU" text="Favor Menu" />
 		<text name="input_NPC_LIST" text="NPC List" />
 			<text name="npc_schedule_plans" text="My plans:" />
-		<text name="input_HUD_EDIT_MODE" text="Toggle HUD Edit" />
+		<text name="input_NPC_HUD_EDIT" text="Toggle HUD Edit" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Drag to move | Corners to resize" />
 		<text name="npc_hud_locked_short" text="Lock Favor HUD" />
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />

--- a/translations/lang_fr.xml
+++ b/translations/lang_fr.xml
@@ -147,7 +147,8 @@
 		<text name="input_FAVOR_MENU" text="Menu des faveurs" />
 		<text name="input_NPC_LIST" text="Liste PNJ" />
 			<text name="npc_schedule_plans" text="Mes projets :" />
-		<text name="input_HUD_EDIT_MODE" text="Basculer édition HUD" />
+		<text name="input_NPC_HUD_EDIT" text="Basculer édition HUD" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Glisser pour déplacer | Coins pour redimensionner" />
 		<text name="npc_hud_locked_short" text="Verrouiller le HUD" />
 		<text name="npc_hud_locked_long" text="Quand verrouillé, la liste des faveurs ne peut pas être déplacée ou redimensionnée" />

--- a/translations/lang_hu.xml
+++ b/translations/lang_hu.xml
@@ -154,7 +154,8 @@
 		<text name="input_FAVOR_MENU" text="Favor Menu" />
 		<text name="input_NPC_LIST" text="NPC List" />
 			<text name="npc_schedule_plans" text="My plans:" />
-		<text name="input_HUD_EDIT_MODE" text="Toggle HUD Edit" />
+		<text name="input_NPC_HUD_EDIT" text="Toggle HUD Edit" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Drag to move | Corners to resize" />
 		<text name="npc_hud_locked_short" text="Lock Favor HUD" />
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />

--- a/translations/lang_id.xml
+++ b/translations/lang_id.xml
@@ -154,7 +154,8 @@
 		<text name="input_FAVOR_MENU" text="Favor Menu" />
 		<text name="input_NPC_LIST" text="NPC List" />
 			<text name="npc_schedule_plans" text="My plans:" />
-		<text name="input_HUD_EDIT_MODE" text="Toggle HUD Edit" />
+		<text name="input_NPC_HUD_EDIT" text="Toggle HUD Edit" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Drag to move | Corners to resize" />
 		<text name="npc_hud_locked_short" text="Lock Favor HUD" />
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />

--- a/translations/lang_it.xml
+++ b/translations/lang_it.xml
@@ -147,7 +147,8 @@
 		<text name="input_FAVOR_MENU" text="Menu favori" />
 		<text name="input_NPC_LIST" text="Lista NPC" />
 			<text name="npc_schedule_plans" text="I miei piani:" />
-		<text name="input_HUD_EDIT_MODE" text="Attiva/disattiva modifica HUD" />
+		<text name="input_NPC_HUD_EDIT" text="Attiva/disattiva modifica HUD" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Trascina per spostare | Angoli per ridimensionare" />
 		<text name="npc_hud_locked_short" text="Blocca HUD favori" />
 		<text name="npc_hud_locked_long" text="Quando bloccato, la lista favori non può essere spostata o ridimensionata" />

--- a/translations/lang_jp.xml
+++ b/translations/lang_jp.xml
@@ -154,7 +154,8 @@
 		<text name="input_FAVOR_MENU" text="Favor Menu" />
 		<text name="input_NPC_LIST" text="NPC List" />
 			<text name="npc_schedule_plans" text="My plans:" />
-		<text name="input_HUD_EDIT_MODE" text="Toggle HUD Edit" />
+		<text name="input_NPC_HUD_EDIT" text="Toggle HUD Edit" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Drag to move | Corners to resize" />
 		<text name="npc_hud_locked_short" text="Lock Favor HUD" />
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />

--- a/translations/lang_kr.xml
+++ b/translations/lang_kr.xml
@@ -154,7 +154,8 @@
 		<text name="input_FAVOR_MENU" text="Favor Menu" />
 		<text name="input_NPC_LIST" text="NPC List" />
 			<text name="npc_schedule_plans" text="My plans:" />
-		<text name="input_HUD_EDIT_MODE" text="Toggle HUD Edit" />
+		<text name="input_NPC_HUD_EDIT" text="Toggle HUD Edit" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Drag to move | Corners to resize" />
 		<text name="npc_hud_locked_short" text="Lock Favor HUD" />
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />

--- a/translations/lang_nl.xml
+++ b/translations/lang_nl.xml
@@ -154,7 +154,8 @@
 		<text name="input_FAVOR_MENU" text="Favor Menu" />
 		<text name="input_NPC_LIST" text="NPC List" />
 			<text name="npc_schedule_plans" text="My plans:" />
-		<text name="input_HUD_EDIT_MODE" text="Toggle HUD Edit" />
+		<text name="input_NPC_HUD_EDIT" text="Toggle HUD Edit" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Drag to move | Corners to resize" />
 		<text name="npc_hud_locked_short" text="Lock Favor HUD" />
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />

--- a/translations/lang_no.xml
+++ b/translations/lang_no.xml
@@ -154,7 +154,8 @@
 		<text name="input_FAVOR_MENU" text="Favor Menu" />
 		<text name="input_NPC_LIST" text="NPC List" />
 			<text name="npc_schedule_plans" text="My plans:" />
-		<text name="input_HUD_EDIT_MODE" text="Toggle HUD Edit" />
+		<text name="input_NPC_HUD_EDIT" text="Toggle HUD Edit" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Drag to move | Corners to resize" />
 		<text name="npc_hud_locked_short" text="Lock Favor HUD" />
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />

--- a/translations/lang_pl.xml
+++ b/translations/lang_pl.xml
@@ -147,7 +147,8 @@
 		<text name="input_FAVOR_MENU" text="Menu przysług" />
 		<text name="input_NPC_LIST" text="Lista NPC" />
 			<text name="npc_schedule_plans" text="Moje plany:" />
-		<text name="input_HUD_EDIT_MODE" text="Przełącz edycję HUD" />
+		<text name="input_NPC_HUD_EDIT" text="Przełącz edycję HUD" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Przeciągnij, aby przesunąć | Rogi, aby skalować" />
 		<text name="npc_hud_locked_short" text="Zablokuj HUD przysług" />
 		<text name="npc_hud_locked_long" text="Gdy zablokowany, lista przysług nie może być przesuwana ani skalowana" />

--- a/translations/lang_pt.xml
+++ b/translations/lang_pt.xml
@@ -154,7 +154,8 @@
 		<text name="input_FAVOR_MENU" text="Favor Menu" />
 		<text name="input_NPC_LIST" text="NPC List" />
 			<text name="npc_schedule_plans" text="My plans:" />
-		<text name="input_HUD_EDIT_MODE" text="Toggle HUD Edit" />
+		<text name="input_NPC_HUD_EDIT" text="Toggle HUD Edit" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Drag to move | Corners to resize" />
 		<text name="npc_hud_locked_short" text="Lock Favor HUD" />
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />

--- a/translations/lang_ro.xml
+++ b/translations/lang_ro.xml
@@ -154,7 +154,8 @@
 		<text name="input_FAVOR_MENU" text="Favor Menu" />
 		<text name="input_NPC_LIST" text="NPC List" />
 			<text name="npc_schedule_plans" text="My plans:" />
-		<text name="input_HUD_EDIT_MODE" text="Toggle HUD Edit" />
+		<text name="input_NPC_HUD_EDIT" text="Toggle HUD Edit" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Drag to move | Corners to resize" />
 		<text name="npc_hud_locked_short" text="Lock Favor HUD" />
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />

--- a/translations/lang_ru.xml
+++ b/translations/lang_ru.xml
@@ -147,7 +147,8 @@
 		<text name="input_FAVOR_MENU" text="Меню услуг" />
 		<text name="input_NPC_LIST" text="Список NPC" />
 			<text name="npc_schedule_plans" text="Мои планы:" />
-		<text name="input_HUD_EDIT_MODE" text="Переключить редактирование HUD" />
+		<text name="input_NPC_HUD_EDIT" text="Переключить редактирование HUD" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Перетащите для перемещения | Углы для масштабирования" />
 		<text name="npc_hud_locked_short" text="Заблокировать HUD услуг" />
 		<text name="npc_hud_locked_long" text="Когда заблокировано, список услуг нельзя перемещать или масштабировать" />

--- a/translations/lang_sv.xml
+++ b/translations/lang_sv.xml
@@ -154,7 +154,8 @@
 		<text name="input_FAVOR_MENU" text="Favor Menu" />
 		<text name="input_NPC_LIST" text="NPC List" />
 			<text name="npc_schedule_plans" text="My plans:" />
-		<text name="input_HUD_EDIT_MODE" text="Toggle HUD Edit" />
+		<text name="input_NPC_HUD_EDIT" text="Toggle HUD Edit" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Drag to move | Corners to resize" />
 		<text name="npc_hud_locked_short" text="Lock Favor HUD" />
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />

--- a/translations/lang_tr.xml
+++ b/translations/lang_tr.xml
@@ -154,7 +154,8 @@
 		<text name="input_FAVOR_MENU" text="Favor Menu" />
 		<text name="input_NPC_LIST" text="NPC List" />
 			<text name="npc_schedule_plans" text="My plans:" />
-		<text name="input_HUD_EDIT_MODE" text="Toggle HUD Edit" />
+		<text name="input_NPC_HUD_EDIT" text="Toggle HUD Edit" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Drag to move | Corners to resize" />
 		<text name="npc_hud_locked_short" text="Lock Favor HUD" />
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />

--- a/translations/lang_uk.xml
+++ b/translations/lang_uk.xml
@@ -147,7 +147,8 @@
 		<text name="input_FAVOR_MENU" text="Меню послуг" />
 		<text name="input_NPC_LIST" text="Список NPC" />
 			<text name="npc_schedule_plans" text="Мої плани:" />
-		<text name="input_HUD_EDIT_MODE" text="Перемкнути редагування HUD" />
+		<text name="input_NPC_HUD_EDIT" text="Перемкнути редагування HUD" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Перетягніть для переміщення | Кути для масштабування" />
 		<text name="npc_hud_locked_short" text="Заблокувати HUD послуг" />
 		<text name="npc_hud_locked_long" text="Коли заблоковано, список послуг не можна переміщувати або масштабувати" />

--- a/translations/lang_vi.xml
+++ b/translations/lang_vi.xml
@@ -154,7 +154,8 @@
 		<text name="input_FAVOR_MENU" text="Favor Menu" />
 		<text name="input_NPC_LIST" text="NPC List" />
 			<text name="npc_schedule_plans" text="My plans:" />
-		<text name="input_HUD_EDIT_MODE" text="Toggle HUD Edit" />
+		<text name="input_NPC_HUD_EDIT" text="Toggle HUD Edit" />
+		<text name="input_NPC_TOGGLE_HUD" text="Toggle Favors HUD" />
 		<text name="npc_hud_drag_hint" text="Drag to move | Corners to resize" />
 		<text name="npc_hud_locked_short" text="Lock Favor HUD" />
 		<text name="npc_hud_locked_long" text="When locked, the favor list cannot be moved or resized" />


### PR DESCRIPTION
﻿## Summary
Playtest-verified NPC Favor on merged Control Center PR #92.

## What this mod gets
- NpcRfPdaGuest (neighbor table pager PASS), NPCFavorHUD, NPCEntity, NPC_HUD_EDIT RShift+Z, translations.

## Test plan
- [ ] Esc neighbor table pager; HUD edit standalone.

## Note
Does **not** change Control Center host behaviour. Safe to merge after SettingsHub #11/#12 and companion delegate PRs.

