### PR TITLE
Move NPC Favor menu key off Dashboard Live map orientation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ All notable changes to the FS25_NPCFavor mod are documented below, organized by 
 
 ## Unreleased
 
+### Changed
+- **Favor menu default key** is now Right Shift + apostrophe. Right Shift + 9 is Dashboard Live map orientation, a widely used cab overlay, so the suite default was moved to avoid that clash.
+
 ### Added
 - **Control Center actions** (suite Control Center, requires SettingsHub): `FAVOR_MENU`, `NPC_LIST`, `NPC_SETTINGS`.
 - **Playtest fixes:** NpcRfPdaGuest (Esc neighbor-table pager), NPCFavorHUD, NPC_HUD_EDIT (RShift+Z), translation sync.

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.7.66</version>
+    <version>1.2.7.67</version>
     <modName>FS25_NPCFavor</modName>
     <title>
         <en>NPC Favor - Living Neighborhood</en>
@@ -50,7 +50,9 @@
     </actions>
     <inputBinding>
         <actionBinding action="NPC_INTERACT" />
-        <actionBinding action="FAVOR_MENU" />
+        <actionBinding action="FAVOR_MENU">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_quote" />
+        </actionBinding>
         <actionBinding action="NPC_LIST" />
         <actionBinding action="NPC_SETTINGS" />
         <actionBinding action="NPC_HUD_EDIT">


### PR DESCRIPTION
## Summary
- Keep Right Shift as the NPC Favor modifier.
- Ship the **Favor menu** default as Right Shift + apostrophe instead of Right Shift + 9.
- Right Shift + 9 is Dashboard Live map orientation, a widely used cab overlay. Both can be used in the cab, so the suite default was moved to avoid that clash.
- Other Favor actions stay unbound except HUD edit (Right Shift + Z), which is unchanged.

## Test plan
- [ ] Fresh profile / Controls: Favor menu default is Right Shift + apostrophe.
- [ ] With Dashboard Live loaded, Right Shift + 9 still flips map orientation and does not open the Favor menu.
- [ ] Existing saves that already rebound this key are unchanged (this only changes the shipped default).
