### PR TITLE
Register the favors HUD show/hide key

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -379,6 +379,9 @@ local npcInteractOriginalFunc = nil
 local favorMenuActionEventId = nil
 local npcListActionEventId = nil
 local hudEditModeActionEventId = nil
+-- [BUILD 10:28] Sibling of the above for the show/hide key. Held so the event can
+-- be found again by the same code that manages hudEditModeActionEventId.
+local hudToggleActionEventId = nil
 local npcSettingsActionEventId = nil
 
 local function npcSettingsActionCallback(self, actionName, inputValue, callbackState, isAnalog)
@@ -479,6 +482,32 @@ local function npcListActionCallback(self, actionName, inputValue, callbackState
 end
 
 -- Toggle HUD Edit Mode via key binding (works on foot and in vehicle)
+--- [BUILD 10:28] Show/hide the favor HUD from the keyboard.
+---
+--- Flips settings.showFavorList, which is the favor HUD's own visibility truth:
+--- NPCFavorHUD:draw and NPCInteractionUI both already honour it, and the Control
+--- Center button flips the same field, so the key and the button cannot disagree.
+--- This deliberately does NOT touch edit mode: moving the panel is the sibling
+--- action's job, and conflating them is what made the two feel unpredictable.
+---
+--- The MasterHUD check repeats the one on the registration below on purpose. The
+--- registration is decided once at load, while MasterHUD presence is what the
+--- suite treats as authoritative at use time, so the callback refuses too rather
+--- than relying on an event that was correct when it was created.
+local function hudToggleActionCallback(self, actionName, inputValue, callbackState, isAnalog)
+    if ((g_currentMission ~= nil and g_currentMission.masterHUD) or g_masterHUD) ~= nil then
+        return
+    end
+    if inputValue <= 0 then return end
+    if npcSystem == nil or npcSystem.settings == nil then
+        print("[NPC Favor] HUD toggle blocked: npcSystem or settings is nil")
+        return
+    end
+    npcSystem.settings.showFavorList = not npcSystem.settings.showFavorList
+    print("[NPC Favor] Favors HUD " ..
+        (npcSystem.settings.showFavorList and "shown" or "hidden") .. " via key")
+end
+
 local function hudEditModeActionCallback(self, actionName, inputValue, callbackState, isAnalog)
     -- 2026-08-22 (Wizard): MasterHUD takeover. When MasterHUD is installed it owns the
     -- suite-wide hide/move binds, so this mod's own per-mod key is deliberately inert:
@@ -609,6 +638,27 @@ local function hookNPCInteractInput()
                     g_inputBinding:setActionEventActive(eventId, true)
                     g_inputBinding:setActionEventTextPriority(eventId, GS_PRIO_NORMAL)
                     g_inputBinding:setActionEventText(eventId, g_i18n:getText("input_NPC_HUD_EDIT") or "Toggle HUD Edit")
+                end
+            end
+
+            -- [BUILD 10:28] Register the show/hide key (default Right Shift and
+            -- backtick). Same MasterHUD gate as the edit key above: with
+            -- MasterHUD installed the suite owns hide and move, so this mod's
+            -- own key stands down and there is still one way to reach it.
+            local hudToggleActionId = InputAction.NPC_TOGGLE_HUD
+            if __rfMhOwnsHudKeys() then hudToggleActionId = nil end
+            if hudToggleActionId ~= nil then
+                local success, eventId = g_inputBinding:registerActionEvent(
+                    hudToggleActionId,
+                    NPCSystem,
+                    hudToggleActionCallback,
+                    false, true, false, false, nil, true
+                )
+                if success and eventId ~= nil then
+                    hudToggleActionEventId = eventId
+                    g_inputBinding:setActionEventActive(eventId, true)
+                    g_inputBinding:setActionEventTextPriority(eventId, GS_PRIO_NORMAL)
+                    g_inputBinding:setActionEventText(eventId, g_i18n:getText("input_NPC_TOGGLE_HUD") or "Toggle Favors HUD")
                 end
             end
 

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.7.73</version>
+    <version>1.2.7.75</version>
     <modName>FS25_NPCFavor</modName>
     <title>
         <en>NPC Favor - Living Neighborhood</en>
@@ -49,12 +49,29 @@
         <action name="NPC_TOGGLE_HUD" category="ONFOOT VEHICLE" />
     </actions>
     <inputBinding>
-        <actionBinding action="NPC_INTERACT" />
-        <actionBinding action="FAVOR_MENU">
-            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_quote" />
+        <!-- Right Shift suite modifier. KEY_grave, not KEY_0: George vetoed
+             RShift+0 for a DashboardLive clash.
+             NOTE (Bob, BUILD 10:21): this reserves the chord, but no
+             registerActionEvent exists for NPC_TOGGLE_HUD anywhere in this mod,
+             so the key does nothing yet. Its sibling NPC_HUD_EDIT registers at
+             main.lua:598; NPC_TOGGLE_HUD only has the Control Center button at
+             main.lua:907. Flagged on the desk rather than fixed here, because
+             adding the registration is Lua and this token fences to modDesc. -->
+        <actionBinding action="NPC_TOGGLE_HUD">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_grave" />
         </actionBinding>
-        <actionBinding action="NPC_LIST" />
-        <actionBinding action="NPC_SETTINGS" />
+        <actionBinding action="NPC_INTERACT">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_e" />
+        </actionBinding>
+        <actionBinding action="FAVOR_MENU">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_9" />
+        </actionBinding>
+        <actionBinding action="NPC_LIST">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_8" />
+        </actionBinding>
+        <actionBinding action="NPC_SETTINGS">
+            <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_7" />
+        </actionBinding>
         <actionBinding action="NPC_HUD_EDIT">
             <binding device="KB_MOUSE_DEFAULT" input="KEY_rshift KEY_z" />
         </actionBinding>


### PR DESCRIPTION
## Summary
- Registers the favors HUD show/hide key (Right Shift plus grave).
- Flips the same flag as the Control Center button. Stands down when MasterHUD owns hide and move.
- Esc menu XML is not in this pull request.

## Test plan
- [ ] Without MasterHUD, Right Shift plus grave shows and hides the favors list.
- [ ] With MasterHUD, that key stays inert.
- [ ] Esc Realistic Farming page still matches the already-merged resistance door.