### PR TITLE
Hide leftover Esc eight-row hairlines

### DIFF
--- a/main.lua
+++ b/main.lua
@@ -130,6 +130,7 @@ source((NPCFavorModDirectory or g_currentModDirectory) .. "src/gui/RfEscModules.
 source((NPCFavorModDirectory or g_currentModDirectory) .. "src/gui/RfPdaMenuPage.lua")
 source((NPCFavorModDirectory or g_currentModDirectory) .. "src/gui/RfEscBootstrap.lua")
 source((NPCFavorModDirectory or g_currentModDirectory) .. "src/gui/RfEscUiDebugger.lua")
+source((NPCFavorModDirectory or g_currentModDirectory) .. "src/gui/NpcGuideDialog.lua")
 source((NPCFavorModDirectory or g_currentModDirectory) .. "src/gui/NpcRfPdaGuest.lua")
 
     print("[NPC Favor] All files loaded successfully")

--- a/modDesc.xml
+++ b/modDesc.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" standalone="no" ?>
 <modDesc descVersion="105">
     <author>TisonK</author>
-    <version>1.2.7.99</version>
+    <version>1.2.7.102</version>
     <modName>FS25_NPCFavor</modName>
     <title>
         <en>NPC Favor - Living Neighborhood</en>

--- a/src/gui/NpcGuideDialog.lua
+++ b/src/gui/NpcGuideDialog.lua
@@ -1,0 +1,379 @@
+-- =========================================================
+-- NPC Favor Field Guide - Field Guide
+-- =========================================================
+-- BUILD 19:15 (George CLOSED DESIGN 18:55 item 5): every Realistic Farming Esc page gets its own
+-- guide, in its own mod, opened from the shared Help footer through this guest's onOpenHelp. The
+-- chrome is SoilGuideDialog's so all of them read as one family; only the words differ.
+-- Rows are { t = "H" | "B" | "S" | "COL", v = "text" }: header, body, spacer, column break.
+-- =========================================================
+
+---@class NpcGuideDialog
+NpcGuideDialog = NpcGuideDialog or {}
+local NpcGuideDialog_mt = Class(NpcGuideDialog, ScreenElement)
+
+local GUIDE_MOD_DIR = (NPCFavorModDirectory or g_currentModDirectory)
+
+NpcGuideDialog.INSTANCE = nil
+NpcGuideDialog.GUI_NAME = "NpcGuideDialog"
+
+NpcGuideDialog.SUBTITLES = {
+    "Neighbours - what the mod adds and this page",
+    "The Esc Page - roster, favours and detail cards",
+    "Favours - accepting, doing and finishing them",
+    "Standing - the seven levels and what they give",
+    "Settings and FAQ - options panel and questions",
+}
+
+NpcGuideDialog.PAGE1 = {
+    { t="H", v="LIVING NEIGHBOURS" },
+    { t="B", v="This mod puts a small number of neighbour" },
+    { t="B", v="farmers into your world. They live on their" },
+    { t="B", v="own farms, work their fields and follow a" },
+    { t="B", v="daily routine." },
+    { t="S", v=" " },
+    { t="B", v="Each neighbour keeps an opinion of you. It" },
+    { t="B", v="starts at the bottom and only moves when you" },
+    { t="B", v="deal with them. Do them a good turn and it" },
+    { t="B", v="rises. Let them down and it falls." },
+    { t="S", v=" " },
+    { t="H", v="FAVOURS IN ONE LINE" },
+    { t="B", v="A neighbour can ask you for help. That" },
+    { t="B", v="request is a favour. Go and talk to them to" },
+    { t="B", v="accept it, do the steps it asks for, and you" },
+    { t="B", v="get paid and gain standing." },
+    { t="S", v=" " },
+    { t="COL", v="" },
+    { t="H", v="THIS ESC PAGE" },
+    { t="B", v="The page in front of you is the NPC Favor" },
+    { t="B", v="part of the Realistic Farming screen. Pick" },
+    { t="B", v="it from the module list on the left." },
+    { t="S", v=" " },
+    { t="B", v="The top table is the neighbour roster: who" },
+    { t="B", v="they are, their standing, the benefits they" },
+    { t="B", v="give you now, and your favour history with" },
+    { t="B", v="them." },
+    { t="S", v=" " },
+    { t="B", v="The table under it lists favours, grouped" },
+    { t="B", v="into Current, Available and Completed." },
+    { t="S", v=" " },
+    { t="B", v="Both tables scroll. Click any row and a" },
+    { t="B", v="detail card opens on the right." },
+    { t="S", v=" " },
+    { t="B", v="This page only reports. You cannot accept" },
+    { t="B", v="or finish a favour from here. That is done" },
+    { t="B", v="out in the world." },
+}
+
+NpcGuideDialog.PAGE2 = {
+    { t="H", v="FINDING THE PAGE" },
+    { t="B", v="Press Escape, open the Realistic Farming" },
+    { t="B", v="screen, then choose NPC Favor from the" },
+    { t="B", v="module list." },
+    { t="S", v=" " },
+    { t="H", v="THE ROSTER TABLE" },
+    { t="B", v="Four columns head the roster: Who, Standing," },
+    { t="B", v="Benefits and History." },
+    { t="S", v=" " },
+    { t="B", v="Who is the neighbour's name." },
+    { t="B", v="Standing shows their level and their score" },
+    { t="B", v="out of 100." },
+    { t="B", v="Benefits lists what that level gives you" },
+    { t="B", v="right now." },
+    { t="B", v="History is your success rate with them, as" },
+    { t="B", v="a percentage and a completed out of total" },
+    { t="B", v="count." },
+    { t="S", v=" " },
+    { t="B", v="The roster is sorted by standing, best" },
+    { t="B", v="first. Long names are shortened to fit." },
+    { t="S", v=" " },
+    { t="COL", v="" },
+    { t="H", v="THE FAVOURS TABLE" },
+    { t="B", v="Its columns are Group, Who, What and" },
+    { t="B", v="Urgency." },
+    { t="S", v=" " },
+    { t="B", v="Group is Current, Available or Completed." },
+    { t="B", v="Current favours are the ones you have" },
+    { t="B", v="accepted. Available ones are waiting for you" },
+    { t="B", v="to go and accept them." },
+    { t="B", v="Urgency is the time left. Completed rows" },
+    { t="B", v="read done." },
+    { t="S", v=" " },
+    { t="H", v="THE DETAIL CARDS" },
+    { t="B", v="Click a roster row and the upper card on the" },
+    { t="B", v="right shows that neighbour in full, with the" },
+    { t="B", v="whole benefits list and the history line." },
+    { t="S", v=" " },
+    { t="B", v="Click a favour row and the lower card shows" },
+    { t="B", v="its group, the neighbour, the full request" },
+    { t="B", v="and the urgency." },
+}
+
+NpcGuideDialog.PAGE3 = {
+    { t="H", v="HOW A FAVOUR STARTS" },
+    { t="B", v="Neighbours ask for help on their own as you" },
+    { t="B", v="play. A new request shows on the favours HUD" },
+    { t="B", v="and as Available on the Esc page." },
+    { t="S", v=" " },
+    { t="B", v="You can also offer help. Stand in front of a" },
+    { t="B", v="neighbour, use the Talk to Neighbour action," },
+    { t="B", v="then pick the offer button in the dialog." },
+    { t="B", v="Offering needs a standing of at least 25." },
+    { t="S", v=" " },
+    { t="H", v="ACCEPTING" },
+    { t="B", v="A request does nothing until you accept it." },
+    { t="B", v="Walk up to the neighbour, talk to them and" },
+    { t="B", v="press Accept Favor. On the HUD an entry you" },
+    { t="B", v="have not taken yet says talk to accept." },
+    { t="S", v=" " },
+    { t="B", v="The clock starts when the request is made," },
+    { t="B", v="not when you accept, so do not leave an" },
+    { t="B", v="offer sitting for long." },
+    { t="S", v=" " },
+    { t="COL", v="" },
+    { t="H", v="DOING THE WORK" },
+    { t="B", v="Most favours are two or three steps, such as" },
+    { t="B", v="going to a farm, out to a field, then back." },
+    { t="B", v="A step ticks off when you get close enough" },
+    { t="B", v="to its place, on foot or in a vehicle." },
+    { t="S", v=" " },
+    { t="B", v="The favours HUD points the way. Each entry" },
+    { t="B", v="shows the neighbour, a needle pointing at" },
+    { t="B", v="the next step, the distance, the step text," },
+    { t="B", v="the time left and a progress bar." },
+    { t="S", v=" " },
+    { t="B", v="A few steps finish by talking to the" },
+    { t="B", v="neighbour instead of by driving there." },
+    { t="S", v=" " },
+    { t="H", v="FINISHING AND FAILING" },
+    { t="B", v="When the last step is done the favour" },
+    { t="B", v="completes by itself. You are paid and your" },
+    { t="B", v="standing with that neighbour rises. Finish" },
+    { t="B", v="well inside the time limit for a bonus." },
+    { t="S", v=" " },
+    { t="B", v="Run out of time and it fails, costing you" },
+    { t="B", v="standing. Cancelling from the Favor Menu" },
+    { t="B", v="costs standing too." },
+}
+
+NpcGuideDialog.PAGE4 = {
+    { t="H", v="THE SEVEN LEVELS" },
+    { t="B", v="Every neighbour has a score from 0 to 100." },
+    { t="B", v="That score sits in one of seven levels." },
+    { t="S", v=" " },
+    { t="B", v="Hostile, 0 to 9." },
+    { t="B", v="Unfriendly, 10 to 24." },
+    { t="B", v="Neutral, 25 to 39." },
+    { t="B", v="Acquaintance, 40 to 59." },
+    { t="B", v="Friend, 60 to 74." },
+    { t="B", v="Close Friend, 75 to 89." },
+    { t="B", v="Best Friend, 90 to 100." },
+    { t="S", v=" " },
+    { t="B", v="Everyone starts at the bottom. Trust has to" },
+    { t="B", v="be earned." },
+    { t="S", v=" " },
+    { t="B", v="The number beside the level on the Esc page" },
+    { t="B", v="is that score. The roster is sorted by it," },
+    { t="B", v="best first." },
+    { t="S", v=" " },
+    { t="B", v="The Benefits column always shows what a" },
+    { t="B", v="neighbour gives you at that level today." },
+    { t="COL", v="" },
+    { t="H", v="WHAT EACH LEVEL GIVES" },
+    { t="B", v="Neutral lets you offer help and gives a" },
+    { t="B", v="small trade discount." },
+    { t="B", v="Acquaintance raises the discount and lets" },
+    { t="B", v="you borrow equipment." },
+    { t="B", v="Friend adds the chance they offer to help" },
+    { t="B", v="you with your own work." },
+    { t="B", v="Close Friend adds gifts from them." },
+    { t="B", v="Best Friend gives the largest discount and" },
+    { t="B", v="shared resources." },
+    { t="S", v=" " },
+    { t="H", v="MOVING THE SCORE" },
+    { t="B", v="Completing a favour is the biggest steady" },
+    { t="B", v="gain. Helping with work, trading and simply" },
+    { t="B", v="speaking to them each day also help." },
+    { t="S", v=" " },
+    { t="B", v="Failing, abandoning or ignoring a favour" },
+    { t="B", v="pushes the score back down, as does an" },
+    { t="B", v="argument." },
+    { t="S", v=" " },
+    { t="B", v="Giving a gift needs a score of 30 and costs" },
+    { t="B", v="money, but it lifts their opinion." },
+}
+
+NpcGuideDialog.PAGE5 = {
+    { t="H", v="SETTINGS PANEL" },
+    { t="B", v="Open the mod's settings panel with the NPC" },
+    { t="B", v="Settings action, Right Shift and 7." },
+    { t="S", v=" " },
+    { t="B", v="It has three sections plus an admin page" },
+    { t="B", v="with save and reset." },
+    { t="S", v=" " },
+    { t="H", v="WHAT YOU CAN CHANGE" },
+    { t="B", v="NPC Behavior sets how many neighbours live" },
+    { t="B", v="in the world, how often they ask for" },
+    { t="B", v="favours, and the hours they work." },
+    { t="S", v=" " },
+    { t="B", v="Display turns the favours HUD, name tags," },
+    { t="B", v="standing bars and map markers on or off," },
+    { t="B", v="and sets the HUD size." },
+    { t="S", v=" " },
+    { t="B", v="Gameplay turns favours and gifts on or off," },
+    { t="B", v="caps how many you can hold at once, sets" },
+    { t="B", v="whether favours expire, and offers easy," },
+    { t="B", v="normal or hard." },
+    { t="COL", v="" },
+    { t="H", v="THE OTHER SCREENS" },
+    { t="B", v="Talk to Neighbour is the E key by default." },
+    { t="B", v="The prompt appears when you stand near one." },
+    { t="S", v=" " },
+    { t="B", v="Favor Menu, Right Shift and 9, lists your" },
+    { t="B", v="favours with time left and reward, and can" },
+    { t="B", v="cancel one." },
+    { t="S", v=" " },
+    { t="B", v="NPC List, Right Shift and 8, is the roster" },
+    { t="B", v="with distance and what each one is doing." },
+    { t="S", v=" " },
+    { t="B", v="All of these can be rebound under Options" },
+    { t="B", v="and Controls." },
+    { t="S", v=" " },
+    { t="H", v="COMMON QUESTIONS" },
+    { t="B", v="Nothing listed? No neighbours have spawned" },
+    { t="B", v="yet, or the system is off in the panel." },
+    { t="S", v=" " },
+    { t="B", v="Can I finish a favour from the Esc page?" },
+    { t="B", v="No. Go to the neighbour or the step place." },
+    { t="S", v=" " },
+    { t="B", v="Settings are stored with your savegame, so" },
+    { t="B", v="save the game after changing them." },
+}
+
+NpcGuideDialog.PAGE_CONTENT = { NpcGuideDialog.PAGE1, NpcGuideDialog.PAGE2, NpcGuideDialog.PAGE3, NpcGuideDialog.PAGE4, NpcGuideDialog.PAGE5 }
+
+-- -- Constructor ------------------------------------------
+
+function NpcGuideDialog.new(target, customMt)
+    local self = ScreenElement.new(target, customMt or NpcGuideDialog_mt)
+    self._contentLineEls = {}
+    self._currentPage = 1
+    return self
+end
+
+--- Loads the dialog into g_gui once. Safe to call twice, and safe to call when some other path has
+--- already registered the same name.
+function NpcGuideDialog.register(modDirectory)
+    if g_gui == nil then return end
+    if g_gui.guis ~= nil and g_gui.guis[NpcGuideDialog.GUI_NAME] ~= nil then return end
+    if modDirectory ~= nil then GUIDE_MOD_DIR = modDirectory end
+    if GUIDE_MOD_DIR == nil then return end
+    NpcGuideDialog.INSTANCE = NpcGuideDialog.new()
+    local ok, err = pcall(function()
+        g_gui:loadGui(GUIDE_MOD_DIR .. "xml/gui/NpcGuideDialog.xml", NpcGuideDialog.GUI_NAME, NpcGuideDialog.INSTANCE)
+    end)
+    if not ok then
+        print("[NPCFavor] NpcGuideDialog: loadGui failed: " .. tostring(err))
+        NpcGuideDialog.INSTANCE = nil
+    end
+end
+
+function NpcGuideDialog.show()
+    if g_gui == nil then return end
+    local loaded = g_gui.guis ~= nil and g_gui.guis[NpcGuideDialog.GUI_NAME] ~= nil
+    if not loaded then
+        NpcGuideDialog.register(GUIDE_MOD_DIR)
+        loaded = g_gui.guis ~= nil and g_gui.guis[NpcGuideDialog.GUI_NAME] ~= nil
+    end
+    if not loaded then return end
+    g_gui:showDialog(NpcGuideDialog.GUI_NAME)
+end
+
+-- -- Lifecycle --------------------------------------------
+
+function NpcGuideDialog:onGuiSetupFinished()
+    NpcGuideDialog:superClass().onGuiSetupFinished(self)
+    self._elCol1 = self:getDescendantById("npcGuide_col1")
+    self._elCol2 = self:getDescendantById("npcGuide_col2")
+    self._elSubtitle = self:getDescendantById("npcGuide_subtitle")
+end
+
+function NpcGuideDialog:onOpen()
+    NpcGuideDialog:superClass().onOpen(self)
+    self._currentPage = 1
+    self:_selectPage(1)
+end
+
+function NpcGuideDialog:onClose()
+    NpcGuideDialog:superClass().onClose(self)
+    self:_clearContent()
+    self._currentPage = 1
+end
+
+-- -- Tabs -------------------------------------------------
+
+function NpcGuideDialog:onClickTab1() self:_selectPage(1) end
+function NpcGuideDialog:onClickTab2() self:_selectPage(2) end
+function NpcGuideDialog:onClickTab3() self:_selectPage(3) end
+function NpcGuideDialog:onClickTab4() self:_selectPage(4) end
+function NpcGuideDialog:onClickTab5() self:_selectPage(5) end
+
+function NpcGuideDialog:_selectPage(pageNum)
+    if self._currentPage == pageNum and #self._contentLineEls > 0 then return end
+    self:_clearContent()
+    self._currentPage = pageNum
+    if self._elSubtitle ~= nil then
+        self._elSubtitle:setText(NpcGuideDialog.SUBTITLES[pageNum] or "")
+    end
+    self:_buildContent(pageNum)
+end
+
+-- -- Content ----------------------------------------------
+
+function NpcGuideDialog:_buildContent(pageNum)
+    local profileH = g_gui:getProfile("npcGuide_colHeader")
+    local profileB = g_gui:getProfile("npcGuide_colBody")
+    local profileS = g_gui:getProfile("npcGuide_colSpacer")
+    if not profileH or not profileB then
+        print("[NPCFavor] NpcGuideDialog: column profiles not found")
+        return
+    end
+    local content = NpcGuideDialog.PAGE_CONTENT[pageNum]
+    if content == nil then return end
+    local currentBox = self._elCol1
+    for _, row in ipairs(content) do
+        if row.t == "COL" then
+            if self._elCol1 ~= nil then self._elCol1:invalidateLayout() end
+            currentBox = self._elCol2
+        elseif currentBox ~= nil then
+            local profile = (row.t == "H") and profileH
+                         or (row.t == "S") and profileS
+                         or profileB
+            if profile ~= nil then
+                local el = TextElement.new()
+                el:loadProfile(profile, true)
+                el:setText(row.v or "")
+                currentBox:addElement(el)
+                el:onGuiSetupFinished()
+                table.insert(self._contentLineEls, { box = currentBox, el = el })
+            end
+        end
+    end
+    if self._elCol2 ~= nil then self._elCol2:invalidateLayout() end
+end
+
+function NpcGuideDialog:_clearContent()
+    for _, entry in ipairs(self._contentLineEls or {}) do
+        if entry.box ~= nil then
+            entry.box:removeElement(entry.el)
+        end
+    end
+    self._contentLineEls = {}
+    if self._elCol1 ~= nil then self._elCol1:invalidateLayout() end
+    if self._elCol2 ~= nil then self._elCol2:invalidateLayout() end
+end
+
+-- -- Button -----------------------------------------------
+
+function NpcGuideDialog:onClickClose()
+    g_gui:closeDialogByName(NpcGuideDialog.GUI_NAME)
+end

--- a/src/gui/NpcRfPdaGuest.lua
+++ b/src/gui/NpcRfPdaGuest.lua
@@ -587,6 +587,9 @@ local NPC_LIST_IDS = {
 --- The static sheet goes dark for the lists: the eight rows, the hairlines and rfFwMore. The
 --- column headers rfFwColA-D stay (they head the roster list). rfFwHintTable is host-hidden.
 local function hideStaticSheet(container)
+    -- BUILD 17:21: the shared table's rows now live in rfFwSheetBox (Income / Depot own it), so it
+    -- goes dark with the static sheet. Nil-safe: an older door copy has no such id.
+    setVis(findDescendant(container, "rfFwSheetBox"), false)
     for i = 1, MAX_ROWS do
         for _, c in ipairs({ "A", "B", "C", "D" }) do
             setVis(findDescendant(container, "rfFwRow" .. i .. c), false)
@@ -848,6 +851,15 @@ local function npcPublishHandles()
     end
 end
 
+--- BUILD 19:15: the Esc Help footer asks whichever module is showing to open its own guide, so
+--- every companion ships and owns its own help instead of borrowing Soil's.
+---@param container table|nil
+function NpcRfPdaGuest.onOpenHelp(container)
+    if NpcGuideDialog ~= nil and type(NpcGuideDialog.show) == "function" then
+        NpcGuideDialog.show()
+    end
+end
+
 function NpcRfPdaGuest.tryRegister()
     npcPublishHandles()
     if RfEscBootstrap ~= nil then
@@ -858,6 +870,12 @@ function NpcRfPdaGuest.tryRegister()
                 profilesXml = MOD_DIR .. "xml/gui/rfEscProfiles.xml",
                 iconPath = "textures/ui/menuIcon.dds",
             })
+            -- BUILD 19:15 (George CLOSED DESIGN 18:55 item 5): load this mod's Field Guide at the
+            -- same moment the door itself loads. A GUI loaded from a mod directory later, once the
+            -- mod's own file system context has closed, fails to open.
+            if NpcGuideDialog ~= nil and type(NpcGuideDialog.register) == "function" then
+                pcall(NpcGuideDialog.register, MOD_DIR)
+            end
             if not doorOk then print("[NPCFavor] NpcRfPdaGuest: WARNING ensureDoor failed (will retry)") end
         end
     end
@@ -876,6 +894,7 @@ function NpcRfPdaGuest.tryRegister()
             end,
             onShow = NpcRfPdaGuest.onShow,
             onHide = NpcRfPdaGuest.onHide,
+            onOpenHelp = NpcRfPdaGuest.onOpenHelp,
         })
         if ok then
             _registered = true

--- a/src/gui/RfEscModules.lua
+++ b/src/gui/RfEscModules.lua
@@ -233,6 +233,11 @@ function RfEscModules:registerModule(def)
         onOpenConsultant = def.onOpenConsultant,
         onOpenSchedule = def.onOpenSchedule,
         onOpenHelp = def.onOpenHelp,
+        -- BUILD 19:15: the shared Esc sheet's row click. registerModule rebuilds the descriptor field
+        -- by field, so a handler that is not named here is silently dropped and the control is dead.
+        -- That is what happened to onOpenFullMarket, onOpenConsultant, onPivotRemote, onLightTick,
+        -- onMoverChanged and onPageStep before it.
+        onSheetRow = def.onSheetRow,
         onPaintConsultant = def.onPaintConsultant,
         -- Same trap again, BUILD 15:46: the CS guest registers onPivotRemote on
         -- its module def (CsRfPdaGuest.lua) but it was missing here, so it was

--- a/src/gui/RfPdaMenuPage.lua
+++ b/src/gui/RfPdaMenuPage.lua
@@ -701,6 +701,18 @@ function RfPdaMenuPage:initialize()
             self:onClickHelpCs()
         end
     }
+    -- BUILD 19:15 (George CLOSED DESIGN 18:55 item 5): ONE generic Help footer for the eight wave-2
+    -- modules. It never names a dialog: it asks the active guest to open its own Field Guide, so each
+    -- companion ships and owns its own help and a door hosted by any mod routes to the right one.
+    -- Soil keeps btnHelp and Crop Stress keeps btnHelpCs, which point at their own guides.
+    self.btnHelpFw = {
+        inputAction = InputAction.MENU_EXTRA_1,
+        showWhenPaused = true,
+        text = tr("rf_pda_btn_help", "Help"),
+        callback = function()
+            self:onClickHelpFw()
+        end
+    }
 
     -- Back only. Help is Soil-only and _syncHostGuestChrome adds it when the Soil
     -- module is the active one; seeding it here leaked Help onto every module's
@@ -1678,9 +1690,15 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     -- header and empty hint go dark on every refresh; NpcRfPdaGuest.onShow alone shows them, so
     -- Income / Dairy / Depot never inherit a live list. Nil-safe: thin doors have no such ids.
     -- BUILD 12:05: plus the two NPC detail cards (rfFwRosterDetailCard / rfFwFavorDetailCard).
+    -- BUILD 17:21: rfFwSheetBox joins the list. No host ever calls a guest onHide, so the shared
+    -- scrolling table has to go dark here or the module that showed it last keeps its rows on
+    -- screen under the next module's headers.
     for _, id in ipairs({ "rfFwRosterBox", "rfFwFavorBox", "rfFwFavEmpty",
                           "rfFwFavColGroup", "rfFwFavColWho", "rfFwFavColWhat", "rfFwFavColUrgency",
-                          "rfFwRosterDetailCard", "rfFwFavorDetailCard" }) do
+                          "rfFwRosterDetailCard", "rfFwFavorDetailCard", "rfFwSheetBox",
+                          -- BUILD 19:15: the selected-row band goes dark with its sheet, so a row
+                          -- read on Depot can never sit under another module's headers.
+                          "rfFwSheetBand" }) do
         local el = self:getDescendantById(id)
         if el ~= nil and type(el.setVisible) == "function" then
             el:setVisible(false)
@@ -1931,12 +1949,14 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
     end
     -- BUILD 12:05 (George CLOSED DESIGN 09:45): Market footer is Back only; the Esc full-Market
     -- door is gone (Prices / Events / Contracts are the whole Market on this page).
+    -- BUILD 19:15: Back + Help for the eight wave-2 modules (Market, Worker Costs, Pro Staff and the
+    -- five framework pages). The Help entry is the generic one; the guest decides which guide opens.
     if isMd then
-        self.menuButtonInfo = { self.btnBack }
+        self.menuButtonInfo = { self.btnBack, self.btnHelpFw }
     elseif isWc then
-        -- BUILD 22:42 (George CLOSED DESIGN 21:26): Back only. Hire / Fire live on the page
+        -- BUILD 22:42 (George CLOSED DESIGN 21:26): Hire / Fire live on the page
         -- (wcBtnHireN / wcBtnFireN); Open Worker Manager is off the Esc footer.
-        self.menuButtonInfo = { self.btnBack }
+        self.menuButtonInfo = { self.btnBack, self.btnHelpFw }
     elseif isCs then
         -- BUILD Help restore 2026-08-12: Back + Help. Consultant chip stays off footer.
         self.menuButtonInfo = { self.btnBack, self.btnHelpCs }
@@ -1949,6 +1969,8 @@ function RfPdaMenuPage:_syncHostGuestChrome(activeId)
         -- Both dialogs stay registered and still open from the PDA/joiner; only the
         -- duplicate bottom-bar buttons go, since the cards now carry that content.
         self.menuButtonInfo = { self.btnBack, self.btnHelp }
+    elseif isFw or activeId == "prostaff" then
+        self.menuButtonInfo = { self.btnBack, self.btnHelpFw }
     else
         self.menuButtonInfo = { self.btnBack }
     end
@@ -3382,10 +3404,42 @@ local function resolveListRowIndex(element)
         if el.rowDataIndex ~= nil then
             return el.rowDataIndex
         end
+        -- BUILD 19:15: rowDataIndex is stamped by THIS page's own populate, so it exists only while
+        -- the host is still the list's data source. A list a guest has taken over - the shared Esc
+        -- sheet - never carries it, and the click resolved to nil. The engine stamps
+        -- element.indexInSection on every populated cell and reads that same field back as the
+        -- clicked row, so it is the row number either way. Index 0 is a section header, never a row.
+        if type(el.indexInSection) == "number" and el.indexInSection > 0 and el.isEmptyCell ~= true then
+            return el.indexInSection
+        end
         el = el.parent
         guard = guard + 1
     end
     return nil
+end
+
+--- BUILD 19:15 (George CLOSED DESIGN 18:55 item 2): a click on the shared Esc table. The engine hands
+--- the clicked cell to the callback; resolveListRowIndex walks up to the row's own rowDataIndex, and
+--- the index goes to whichever guest is showing. A guest without onSheetRow is a quiet no-op, which is
+--- what Income wants: it has no band.
+function RfPdaMenuPage:onClickFwSheetRow(element)
+    local index = resolveListRowIndex(element)
+    if index == nil or index < 1 then return end
+    local host = self:_getHost()
+    local active = host and host.getActivePanel and host:getActivePanel()
+    if active ~= nil and type(active.onSheetRow) == "function" then
+        pcall(active.onSheetRow, index)
+    end
+end
+
+--- BUILD 19:15 (item 5): the generic Help footer. Every wave-2 guest publishes onOpenHelp and owns its
+--- own Field Guide dialog inside its own mod, so this never names one.
+function RfPdaMenuPage:onClickHelpFw()
+    local host = self:_getHost()
+    local active = host and host.getActivePanel and host:getActivePanel()
+    if active ~= nil and type(active.onOpenHelp) == "function" then
+        pcall(active.onOpenHelp, self.rfHostPlaceholder or self)
+    end
 end
 
 function RfPdaMenuPage:onClickFieldRow(element)
@@ -3569,5 +3623,18 @@ end
 
 function RfPdaMenuPage:onClickMdNcDays(element)
     _mdGuestCall(self, "onNcDays", self.rfHostPlaceholder or self, element)
+end
+
+--- BUILD 17:21 (George CLOSED DESIGN 14:00): pick an open deal on the Contracts page, then cancel
+--- it. mdCtRow1..5 are invisible hit targets laid over the five contract rows, so the engine hands
+--- the clicked Button to the callback and the guest reads the row number off its id; the pick is
+--- stored as a contract id, never a row index. Cancel is ONE chip (mdCancelBtn), and the guest owns
+--- every gate: BetterContracts stand-down, "is the pick still an open deal", and the request itself.
+function RfPdaMenuPage:onClickMdCtRow(element)
+    _mdGuestCall(self, "onContractRow", self.rfHostPlaceholder or self, element)
+end
+
+function RfPdaMenuPage:onClickMdCancel()
+    _mdGuestCall(self, "onCancelContract", self.rfHostPlaceholder or self)
 end
 

--- a/xml/gui/NpcGuideDialog.xml
+++ b/xml/gui/NpcGuideDialog.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="utf-8" standalone="no" ?>
+<!--
+    NPC Favor Field Guide - Field Guide
+    5 tabs. Content is built in Lua and swapped per tab (one column pair).
+    Chrome copied from SoilGuideDialog so every Realistic Farming guide reads the same.
+    Controller: NpcGuideDialog
+-->
+<GUI onOpen="onOpen" onClose="onClose" onCreate="onCreate">
+  <GuiElement profile="newLayer"/>
+  <Bitmap profile="dialogFullscreenBg" id="dialogBg"/>
+
+  <GuiElement profile="npcGuide_bg" id="dialogElement">
+
+    <ThreePartBitmap profile="fs25_dialogBgMiddle"/>
+    <ThreePartBitmap profile="fs25_dialogBgTop"/>
+    <ThreePartBitmap profile="fs25_dialogBgBottom"/>
+
+    <GuiElement profile="fs25_dialogContentContainer">
+
+      <Text profile="fs25_dialogTitle" id="npcGuide_title" text="NPC Favor Field Guide" position="0px -28px"/>
+
+      <BoxLayout profile="npcGuide_tabRow" position="0px -66px">
+        <Button profile="npcGuide_tab" id="npcGuide_tab1" text="Neighbours" onClick="onClickTab1"/>
+        <Button profile="npcGuide_tab" id="npcGuide_tab2" text="The Esc Page" onClick="onClickTab2"/>
+        <Button profile="npcGuide_tab" id="npcGuide_tab3" text="Favours" onClick="onClickTab3"/>
+        <Button profile="npcGuide_tab" id="npcGuide_tab4" text="Standing" onClick="onClickTab4"/>
+        <Button profile="npcGuide_tab" id="npcGuide_tab5" text="Settings and FAQ" onClick="onClickTab5"/>
+      </BoxLayout>
+
+      <Text profile="npcGuide_subtitle" id="npcGuide_subtitle" text="" position="0px -110px"/>
+
+      <GuiElement profile="npcGuide_colPanel" position="-253px -138px">
+        <Bitmap profile="npcGuide_colBg" position="0px 0px"/>
+        <BoxLayout profile="npcGuide_col" id="npcGuide_col1" position="0px -8px"/>
+      </GuiElement>
+
+      <GuiElement profile="npcGuide_colPanel" position="253px -138px">
+        <Bitmap profile="npcGuide_colBgAlt" position="0px 0px"/>
+        <BoxLayout profile="npcGuide_col" id="npcGuide_col2" position="0px -8px"/>
+      </GuiElement>
+
+    </GuiElement>
+
+    <BoxLayout profile="fs25_dialogButtonBox">
+      <Button profile="buttonOK" text="Close" onClick="onClickClose"/>
+    </BoxLayout>
+
+  </GuiElement>
+
+  <GUIProfiles>
+
+    <Profile name="npcGuide_bg" extends="fs25_dialogBg">
+      <size value="1120px 930px"/>
+    </Profile>
+
+    <Profile name="npcGuide_tabRow" extends="emptyPanel" with="anchorTopCenter">
+      <size value="960px 38px"/>
+      <flowDirection value="horizontal"/>
+      <elementSpacing value="10px"/>
+    </Profile>
+
+    <!-- The guide tabs and Close stay buttonOK: dialog chrome, not Esc overlay chips. -->
+    <Profile name="npcGuide_tab" extends="buttonOK">
+      <size value="174px 36px"/>
+      <textSize value="11px"/>
+      <textUpperCase value="true"/>
+    </Profile>
+
+    <Profile name="npcGuide_subtitle" extends="fs25_textDefault" with="anchorTopCenter">
+      <size value="960px 22px"/>
+      <textSize value="11px"/>
+      <textColor value="0.85 0.75 0.30 0.90"/>
+      <textAlignment value="center"/>
+    </Profile>
+
+    <Profile name="npcGuide_colPanel" extends="emptyPanel" with="anchorTopCenter">
+      <size value="510px 630px"/>
+    </Profile>
+    <Profile name="npcGuide_colBg" extends="baseReference" with="anchorTopCenter">
+      <size value="510px 630px"/>
+      <imageColor value="0.08 0.08 0.12 0.90"/>
+    </Profile>
+    <Profile name="npcGuide_colBgAlt" extends="baseReference" with="anchorTopCenter">
+      <size value="510px 630px"/>
+      <imageColor value="0.06 0.10 0.14 0.90"/>
+    </Profile>
+
+    <Profile name="npcGuide_col" extends="emptyPanel" with="anchorTopCenter">
+      <size value="494px 614px"/>
+      <flowDirection value="vertical"/>
+      <useFullVisibility value="false"/>
+      <alignmentX value="left"/>
+      <elementSpacing value="3px"/>
+    </Profile>
+
+    <Profile name="npcGuide_colHeader" extends="fs25_textDefault" with="anchorTopLeft">
+      <size value="472px 22px"/>
+      <textSize value="15px"/>
+      <textBold value="true"/>
+      <textUpperCase value="true"/>
+      <textColor value="1 0.8 0.2 1"/>
+      <textAlignment value="left"/>
+    </Profile>
+    <Profile name="npcGuide_colBody" extends="fs25_textDefault" with="anchorTopLeft">
+      <size value="472px 19px"/>
+      <textSize value="14px"/>
+      <textColor value="1 1 1 1"/>
+      <textAlignment value="left"/>
+    </Profile>
+    <Profile name="npcGuide_colSpacer" extends="fs25_textDefault" with="anchorTopLeft">
+      <size value="472px 10px"/>
+      <textSize value="8px"/>
+      <textColor value="0.0 0.0 0.0 0.0"/>
+    </Profile>
+
+  </GUIProfiles>
+</GUI>

--- a/xml/gui/RfPdaMenuPage.xml
+++ b/xml/gui/RfPdaMenuPage.xml
@@ -622,54 +622,92 @@
                                  take it with an inline size rather than one profile per orientation. Declared
                                  before the cells so text paints over them. Per-cell hasFrame would have been 144
                                  frame rects for the same picture. -->
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleHead" position="10px -64px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow1" position="10px -92px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow2" position="10px -120px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow3" position="10px -148px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow4" position="10px -176px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow5" position="10px -204px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow6" position="10px -232px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow7" position="10px -260px" size="1120px 1px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol1" position="300px -36px" size="1px 250px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol2" position="600px -36px" size="1px 250px"/>
-                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol3" position="840px -36px" size="1px 250px"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleHead" position="10px -64px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow1" position="10px -92px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow2" position="10px -120px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow3" position="10px -148px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow4" position="10px -176px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow5" position="10px -204px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow6" position="10px -232px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleRow7" position="10px -260px" size="1120px 1px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol1" position="300px -36px" size="1px 250px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol2" position="600px -36px" size="1px 250px" visible="false"/>
+                            <Bitmap profile="RF_EscCardRule" id="rfFwRuleCol3" position="840px -36px" size="1px 250px" visible="false"/>
                             <Text profile="RF_FwColHeader" id="rfFwColA" position="10px -40px" size="280px 22px" text=""/>
                             <Text profile="RF_FwColHeader" id="rfFwColB" position="310px -40px" size="280px 22px" text=""/>
                             <Text profile="RF_FwColHeader" id="rfFwColC" position="610px -40px" size="220px 22px" text=""/>
                             <Text profile="RF_FwColHeader" id="rfFwColD" position="850px -40px" size="280px 22px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1A" position="10px -68px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1B" position="310px -68px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1C" position="610px -68px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow1D" position="850px -68px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2A" position="10px -96px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2B" position="310px -96px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2C" position="610px -96px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow2D" position="850px -96px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3A" position="10px -124px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3B" position="310px -124px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3C" position="610px -124px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow3D" position="850px -124px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4A" position="10px -152px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4B" position="310px -152px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4C" position="610px -152px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow4D" position="850px -152px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5A" position="10px -180px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5B" position="310px -180px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5C" position="610px -180px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow5D" position="850px -180px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6A" position="10px -208px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6B" position="310px -208px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6C" position="610px -208px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow6D" position="850px -208px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7A" position="10px -236px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7B" position="310px -236px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7C" position="610px -236px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow7D" position="850px -236px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8A" position="10px -264px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8B" position="310px -264px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8C" position="610px -264px" size="220px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwRow8D" position="850px -264px" size="280px 20px" text=""/>
-                            <Text profile="RF_TreatTargetLine" id="rfFwMore" position="10px -300px" size="1120px 20px" text=""/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1A" position="10px -68px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1B" position="310px -68px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1C" position="610px -68px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow1D" position="850px -68px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2A" position="10px -96px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2B" position="310px -96px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2C" position="610px -96px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow2D" position="850px -96px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3A" position="10px -124px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3B" position="310px -124px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3C" position="610px -124px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow3D" position="850px -124px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4A" position="10px -152px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4B" position="310px -152px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4C" position="610px -152px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow4D" position="850px -152px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5A" position="10px -180px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5B" position="310px -180px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5C" position="610px -180px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow5D" position="850px -180px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6A" position="10px -208px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6B" position="310px -208px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6C" position="610px -208px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow6D" position="850px -208px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7A" position="10px -236px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7B" position="310px -236px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7C" position="610px -236px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow7D" position="850px -236px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8A" position="10px -264px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8B" position="310px -264px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8C" position="610px -264px" size="220px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwRow8D" position="850px -264px" size="280px 20px" text="" visible="false"/>
+                            <Text profile="RF_TreatTargetLine" id="rfFwMore" position="10px -548px" size="1120px 20px" text=""/>
+                            <!-- BUILD 17:21 (George CLOSED DESIGN 14:00): the shared table scrolls. ONE SmoothList
+                                 under this GuiElement host (rfFwTableBlock is a GuiElement, never a Map Bitmap: the
+                                 hang fence), the NPC Favor nest, the sheet's own 28px pitch and the same four column
+                                 X as rfFwColA..D, so the headers above it still line up. Painted by whichever Table
+                                 guest is showing (Income, Depot); hidden by default and hidden again on every host
+                                 refresh, so no module inherits another's rows. The 32 rfFwRow* cells above stay
+                                 declared and unused: Dairy, NPC Favor and Pro Staff each hide them by id, and a door
+                                 must never lose an id a shipped guest still names. -->
+                            <!-- BUILD 19:15 (George CLOSED DESIGN 18:55): the sheet fills the bay like the Soil field
+                                 list - 480 tall, 48px rows, 18px cells - so ten full rows read at a glance instead of
+                                 eight cramped ones. Bottom sits at -540; rfFwMore follows at -548 and rfFwHintTable at
+                                 -576, and nothing in this block goes below -740, which is what keeps the Pro Staff
+                                 Buy / Run strip at -748 clear. Cell X and widths are untouched so rfFwColA..D still
+                                 head their own columns. The ListItem carries the row click; the host resolves the row
+                                 index and hands it to whichever guest is showing. -->
+                            <GuiElement profile="RF_FwListBox" id="rfFwSheetBox" position="10px -60px" size="1120px 480px" visible="false">
+                                <SmoothList id="rfFwSheetList" profile="RF_FwSheetList" size="1112px 480px" handleFocus="false"
+                                            startClipperElementName="rfFwSheetStart" endClipperElementName="rfFwSheetEnd">
+                                    <ListItem profile="RF_FwSheetItem" height="48px" onClick="onClickFwSheetRow">
+                                        <Bitmap profile="RF_RowBg" name="alternating"/>
+                                        <Text profile="RF_FwSheetCell" name="rfFwSheetA" position="0px 0px" size="280px 48px"/>
+                                        <Text profile="RF_FwSheetCell" name="rfFwSheetB" position="300px 0px" size="280px 48px"/>
+                                        <Text profile="RF_FwSheetCell" name="rfFwSheetC" position="600px 0px" size="220px 48px"/>
+                                        <Text profile="RF_FwSheetCell" name="rfFwSheetD" position="840px 0px" size="272px 48px"/>
+                                    </ListItem>
+                                </SmoothList>
+                                <Bitmap profile="RF_SheetStartClipper" name="rfFwSheetStart"/>
+                                <Bitmap profile="RF_SheetStopClipper" name="rfFwSheetEnd"/>
+                                <ThreePartBitmap profile="fs25_subCategoryListSliderBox">
+                                    <Slider profile="fs25_listSlider" dataElementId="rfFwSheetList" hideParentWhenEmpty="true"/>
+                                </ThreePartBitmap>
+                            </GuiElement>
+                            <!-- BUILD 19:15: the readout for the row the player clicked. Text only, no chip. Hidden by
+                                 default and hidden again on every host refresh beside rfFwSheetBox, so it can never
+                                 carry one module's row onto another module's page. The Depot guest fills it; Income
+                                 has no band and its onSheetRow is a no-op. -->
+                            <Text profile="RF_SheetBand" id="rfFwSheetBand" position="10px -664px" size="1120px 72px"
+                                  textMaxNumLines="3" textVerticalAlignment="top" visible="false" text=""/>
                             <!-- BUILD 00:06 (George CLOSED DESIGN 23:12): the rfFwPagePrev / rfFwPageNext row pager is gone;
                                  the NPC Favor tables scroll (rfFwRosterList / rfFwFavorList below). The host keyEvent page
                                  belt (. / , keys) still serves a guest that registers onPageStep (Dairy cards). -->
@@ -689,7 +727,7 @@
                                     visible="false" text="" onClick="onClickPsFlush"/>
                             <Text profile="RF_HintText" id="rfFwEmptyHint" position="10px -68px" size="1120px 44px"
                                   textMaxNumLines="2" visible="false" text=""/>
-                            <Text profile="RF_HintText" id="rfFwHintTable" position="10px -336px" size="1120px 80px"
+                            <Text profile="RF_HintText" id="rfFwHintTable" position="10px -576px" size="1120px 80px"
                                   textMaxNumLines="3" textVerticalAlignment="top" text=""/>
                             <!-- BUILD 00:06 (George CLOSED DESIGN 23:12, Ash 00:06): NPC Favor scrollable tables. Two SmoothLists
                                  under this GuiElement host (rfFwTableBlock is a GuiElement, never a Map Bitmap: the hang fence),
@@ -1504,6 +1542,20 @@
                                 <Text profile="RF_HintText" id="mdCtMore" textSize="13px" position="10px -186px" size="530px 20px" text=""/>
                                 <Text profile="RF_HintText" id="mdContractsEmpty" textSize="13px" position="10px -62px" size="530px 44px"
                                       textMaxNumLines="2" visible="false" text=""/>
+                                <!-- BUILD 17:21 (George CLOSED DESIGN 14:00): pick an open deal, then Cancel it. The five
+                                     hit targets sit ON the row bands and paint nothing (RF_CtRowHit); they are declared
+                                     after the row Texts so the transparent button draws over the text without hiding it.
+                                     ONE Cancel chip, never one per row. handleFocus="false" and the profile's
+                                     isTriggerableByGlobalAction="false" are the overlay-chip law: SPACE never confirms it. -->
+                                <Button profile="RF_CtRowHit" id="mdCtRow1" position="10px -62px" size="530px 24px" handleFocus="false" text="" onClick="onClickMdCtRow"/>
+                                <Button profile="RF_CtRowHit" id="mdCtRow2" position="10px -86px" size="530px 24px" handleFocus="false" text="" onClick="onClickMdCtRow"/>
+                                <Button profile="RF_CtRowHit" id="mdCtRow3" position="10px -110px" size="530px 24px" handleFocus="false" text="" onClick="onClickMdCtRow"/>
+                                <Button profile="RF_CtRowHit" id="mdCtRow4" position="10px -134px" size="530px 24px" handleFocus="false" text="" onClick="onClickMdCtRow"/>
+                                <Button profile="RF_CtRowHit" id="mdCtRow5" position="10px -158px" size="530px 24px" handleFocus="false" text="" onClick="onClickMdCtRow"/>
+                                <Text profile="RF_HintText" id="mdCtSelected" textSize="13px" position="10px -212px" size="530px 20px" text=""/>
+                                <Button profile="RF_CsPivotBtn" id="mdCancelBtn" position="10px -238px" size="170px 32px" handleFocus="false" visible="false" text="" onClick="onClickMdCancel"/>
+                                <Text profile="RF_HintText" id="mdCancelHint" textSize="13px" position="190px -234px" size="350px 40px"
+                                      textMaxNumLines="2" text=""/>
                             </GuiElement>
                             <GuiElement profile="RF_EscCardFrame" id="mdNewContractCard" position="580px 0px" size="550px 344px">
                                 <Text profile="RF_SectionTitle" id="mdNewContractTitle" position="10px -6px" size="530px 22px" text=""/>

--- a/xml/gui/rfEscProfiles.xml
+++ b/xml/gui/rfEscProfiles.xml
@@ -729,6 +729,49 @@
         <textVerticalAlignment value="middle"/>
     </Profile>
 
+    <!-- BUILD 17:21: the shared Esc table list. 28px rows are the sheet's own pitch, so the four
+         column headers above the box still line up; the clippers are 12px because the engine's own
+         are 39px, sized for the 420px roster box. -->
+    <Profile name="RF_FwSheetList" extends="RF_SmoothList">
+        <size value="1112px 480px"/>
+        <handleFocus value="false"/>
+    </Profile>
+    <!-- BUILD 19:15: the Soil field-list family - 48px rows and 18px cells - so the shared table reads
+         at the same weight as the Soil list instead of a denser one. -->
+    <Profile name="RF_FwSheetItem" extends="RF_ListRow">
+        <height value="48px"/>
+    </Profile>
+    <Profile name="RF_FwSheetCell" extends="RF_FwListCell">
+        <textSize value="18px"/>
+        <textBold value="false"/>
+        <textMaxNumLines value="1"/>
+        <textVerticalAlignment value="middle"/>
+    </Profile>
+    <!-- 24px is proportional for a 480px box the way the engine's own 39px is for the 420px roster. -->
+    <Profile name="RF_SheetStartClipper" extends="fs25_secondaryMenuStartClipper">
+        <height value="24px"/>
+    </Profile>
+    <Profile name="RF_SheetStopClipper" extends="fs25_secondaryMenuStopClipper">
+        <height value="24px"/>
+    </Profile>
+    <!-- BUILD 19:15: the selected-row readout under the sheet. Three lines of hint text, top aligned. -->
+    <Profile name="RF_SheetBand" extends="RF_HintText">
+        <textSize value="18px"/>
+        <textMaxNumLines value="3"/>
+        <textVerticalAlignment value="top"/>
+    </Profile>
+
+    <!-- BUILD 17:21 (George CLOSED DESIGN 14:00): an invisible per-row hit target for the Esc Market
+         contracts rows. It extends the pivot chip so the overlay-chip law's guards come with it
+         (hideKeyboardGlyph, isTriggerableByGlobalAction false, so SPACE can never activate a row);
+         nothing paints because fs25_wideButton's own background is emptyPanel-transparent, the icon
+         is sized away and the label is empty. -->
+    <Profile name="RF_CtRowHit" extends="RF_CsPivotBtn">
+        <size value="530px 24px"/>
+        <iconSize value="0px 0px"/>
+        <textSize value="1px"/>
+    </Profile>
+
     <!-- BUILD 11:40 (George CLOSED DESIGN 11:25): the in-card herd / milk breed lists on the Dairy cards.
          20px rows = four visible in the 80px box (today's density); the slider shows only when rows overflow. -->
     <Profile name="RF_DairyBreedList" extends="RF_SmoothList">


### PR DESCRIPTION
## Summary
- Leftover eight-row hairlines on the shared Realistic Farming page stay hidden.

## Test plan
- [ ] Full restart. Esc NPC Favor: no ghost eight-row table.
